### PR TITLE
Add Remote Player File Installation

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -357,3 +357,18 @@ msgstr ""
 msgctxt "#32013"
 msgid "Display Trakt list management options in TMDb details list"
 msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32014"
+msgid "Player Function"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32015"
+msgid "Players URL"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32016"
+msgid "Update Players from URL"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -24,76 +24,6 @@ msgctxt "#30001"
 msgid "Arabic (Saudi Arabia)"
 msgstr ""
 
-#: /resources/settings.xml
-msgctxt "#32000"
-msgid "TMDb API Key"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32001"
-msgid "OMDb API Key"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32002"
-msgid "Days to cache details"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32003"
-msgid "Days to cache lists"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32004"
-msgid "MPAA Rating Prefix"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32005"
-msgid "Language and Country"
-msgstr ""
-
-#: /resources/lib/utils.py
-msgctxt "#32006"
-msgid "Choose item"
-msgstr ""
-
-#: /resources/lib/requestapi.py
-msgctxt "#32007"
-msgid "Missing/Invalid"
-msgstr ""
-
-#: /resources/lib/requestapi.py
-msgctxt "#32008"
-msgid "API Key"
-msgstr ""
-
-#: /resources/lib/requestapi.py
-msgctxt "#32009"
-msgid "You must enter a valid API key to use this add-on"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32010"
-msgid "Authenticate Trakt Account..."
-msgstr ""
-
-#: /resources/lib/traktapi.py
-msgctxt "#32011"
-msgid "Token"
-msgstr ""
-
-#: /resources/lib/traktapi.py
-msgctxt "#32012"
-msgid "You must Authenticate your Trakt account to use this feature."
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32013"
-msgid "Display Trakt list management options in TMDb details list"
-msgstr ""
-
 msgctxt "#30002"
 msgid "Belarusian (Belarus)"
 msgstr ""
@@ -356,4 +286,74 @@ msgstr ""
 
 msgctxt "#30067"
 msgid "Zulu (South Africa)"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32000"
+msgid "TMDb API Key"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32001"
+msgid "OMDb API Key"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32002"
+msgid "Days to cache details"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32003"
+msgid "Days to cache lists"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32004"
+msgid "MPAA Rating Prefix"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32005"
+msgid "Language and Country"
+msgstr ""
+
+#: /resources/lib/utils.py
+msgctxt "#32006"
+msgid "Choose item"
+msgstr ""
+
+#: /resources/lib/requestapi.py
+msgctxt "#32007"
+msgid "Missing/Invalid"
+msgstr ""
+
+#: /resources/lib/requestapi.py
+msgctxt "#32008"
+msgid "API Key"
+msgstr ""
+
+#: /resources/lib/requestapi.py
+msgctxt "#32009"
+msgid "You must enter a valid API key to use this add-on"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32010"
+msgid "Authenticate Trakt Account..."
+msgstr ""
+
+#: /resources/lib/traktapi.py
+msgctxt "#32011"
+msgid "Token"
+msgstr ""
+
+#: /resources/lib/traktapi.py
+msgctxt "#32012"
+msgid "You must Authenticate your Trakt account to use this feature."
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32013"
+msgid "Display Trakt list management options in TMDb details list"
 msgstr ""

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -46,9 +46,9 @@ def update_players():
                     if os.path.isfile(file_path):
                         os.unlink(file_path)
                     elif os.path.isdir(file_path):
-                        shutil.rmtree(file_path)
-                except:
-                    pass
+                        utils.recursive_delete_dir(file_path)
+                except Exception as e:
+                    utils.kodi_log('Could not delete file {0}: {1}'.format(file_path, str(e)))
     
         with zipfile.ZipFile(BytesIO(response.content)) as player_zip:
             for item in [x for x in player_zip.namelist() if x.endswith('.json')]:
@@ -56,16 +56,14 @@ def update_players():
                 if not filename:
                     continue
                     
-                file = player_zip.open(item)
-                target = open(os.path.join(_extract_to, filename), 'w')
-                
-                with file, target:
-                    shutil.copyfileobj(file, target)
+                _file = player_zip.open(item)
+                with open(os.path.join(_extract_to, filename), 'w') as target:
+                    target.write(_file.read())
         
         try:
             os.remove(_temp_zip)
-        except:
-            pass
+        except Exception as e:
+            utils.kodi_log('Could not delete package {0}: {1}'.format(_temp_zip, str(e)))
     else:
         xbmcgui.Dialog().ok(_addon.getAddonInfo('name'), 'The provided player URL is either invalid or inaccesible.')
         

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,5 +1,6 @@
 import sys
 import xbmc
+import xbmcaddon
 import xbmcgui
 import xbmcvfs
 import datetime
@@ -10,6 +11,8 @@ from collections import defaultdict
 from resources.lib.plugin import Plugin
 from resources.lib.kodilibrary import KodiLibrary
 from resources.lib.traktapi import traktAPI
+_addonname = 'plugin.video.themoviedb.helper'
+_addon = xbmcaddon.Addon(_addonname)
 
 
 def string_format_map(fmt, d):
@@ -20,6 +23,25 @@ def string_format_map(fmt, d):
         return fmt.format(**{part[1]: d[part[1]] for part in parts})
     else:
         return fmt.format(**d)
+
+
+def update_players():
+    import zipfile
+    
+    _players_url = _addon.getSetting('players_url')
+    _player_path = 'special://profile/addon_data/plugin.video.themoviedb.helper/players'
+    _extract_to = xbmc.translatePath(_player_path)
+    
+    with open(_player_path + '/temp.zip', 'w') as zip:
+        response = utils.open_url(_players_url)
+        
+        if response:
+            zip.write(response.content)
+    
+    _player_zip = zipfile.ZipFile(zip,  'r')
+    
+    for item in _player_zip.infolist():
+        xbmc.log('{0}'.format(item.filename), level=xbmc.LOGNOTICE)
 
 
 class Player(Plugin):

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -4,6 +4,9 @@ import xbmcaddon
 import xbmcgui
 import xbmcvfs
 import datetime
+from io import BytesIO
+import os
+import zipfile
 import resources.lib.utils as utils
 from json import loads
 from string import Formatter
@@ -26,11 +29,6 @@ def string_format_map(fmt, d):
 
 
 def update_players():
-    from io import BytesIO
-    import os
-    import shutil
-    import zipfile
-    
     _players_url = _addon.getSetting('players_url')
     _player_path = 'special://profile/addon_data/plugin.video.themoviedb.helper/players'
     _extract_to = xbmc.translatePath(_player_path)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -267,7 +267,7 @@ def open_url(url, stream=False, check=False, cred=None, count=0):
             return True if valid else False
             
         if valid == 'auth' and not cred:
-            cred = (get_keyboard(heading='Username'), get_keyboard(heading='Password'))
+            cred = (xbmcgui.Dialog().input(heading='Username') or '', xbmcgui.Dialog().input(heading='Password', option=xbmcgui.ALPHANUM_HIDE_INPUT) or '')
             
         response = requests.get(url, timeout=10.000, stream=stream, auth=cred)
 
@@ -276,7 +276,7 @@ def open_url(url, stream=False, check=False, cred=None, count=0):
             
             if retry and count < 3:
                 count += 1
-                cred = (get_keyboard(heading='Username'), get_keyboard(heading='Password'))
+                cred = (xbmcgui.Dialog().input(heading='Username') or '', xbmcgui.Dialog().input(heading='Password', option=xbmcgui.ALPHANUM_HIDE_INPUT) or '')
                 
                 response = open_url(url, stream, check, cred, count)
             else:

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -202,12 +202,20 @@ def make_kwparams(params):
                                       'exclude_key', 'exclude_value'])
                                       
 
-def get_keyboard(default="", heading="", hidden=False):
-    keyboard = xbmc.Keyboard(default, heading, hidden)
-    keyboard.doModal()
-    if keyboard.isConfirmed():
-        return keyboard.getText()
-    return default
+def recursive_delete_dir(fullpath):
+    '''helper to recursively delete a directory'''
+    success = True
+    if not isinstance(fullpath, unicode):
+        fullpath = fullpath.decode("utf-8")
+    dirs, files = xbmcvfs.listdir(fullpath)
+    for file in files:
+        file = file.decode("utf-8")
+        success = xbmcvfs.delete(os.path.join(fullpath, file))
+    for directory in dirs:
+        directory = directory.decode("utf-8")
+        success = recursive_delete_dir(os.path.join(fullpath, directory))
+    success = xbmcvfs.rmdir(fullpath)
+    return success
                                       
                                       
 def _is_url(url):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,10 +4,13 @@
         <setting label="$ADDON[plugin.video.themoviedb.helper 32000]" type="text" id="tmdb_apikey" />
         <setting label="$ADDON[plugin.video.themoviedb.helper 32001]" type="text" id="omdb_apikey" />
         <setting label="$ADDON[plugin.video.themoviedb.helper 32002]" type="enum" id="cache_details_days" values="14|21|30|60" />
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32003]" type="enum" id="cache_list_days" values="1|2|3|4|5|6|7|14|21|30"/>
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32004]" type="text" id="mpaa_prefix" default="Rated"/>
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32005]" type="select" id="language" lvalues="30000|30001|30002|30003|30004|30005|30006|30007|30008|30009|30010|30011|30012|30013|30014|30015|30016|30017|30018|30019|30020|30021|30022|30023|30024|30025|30026|30027|30028|30029|30030|30031|30030|30033|30034|30035|30036|30037|30038|30039|30040|30041|30042|30043|30044|30045|30046|30047|30048|30049|30050|30051|30052|30053|30054|30055|30056|30057|30058|30059|30060|30061|30062|30063|30064|30065|30066|30067" default="18"/>
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32010]" type="action" action="RunScript(plugin.video.themoviedb.helper, authenticate_trakt)" option="close"/>
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32013]" type="bool" id="trakt_management" default="false"/>
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32003]" type="enum" id="cache_list_days" values="1|2|3|4|5|6|7|14|21|30" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32004]" type="text" id="mpaa_prefix" default="Rated "/>
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32005]" type="select" id="language" lvalues="30000|30001|30002|30003|30004|30005|30006|30007|30008|30009|30010|30011|30012|30013|30014|30015|30016|30017|30018|30019|30020|30021|30022|30023|30024|30025|30026|30027|30028|30029|30030|30031|30030|30033|30034|30035|30036|30037|30038|30039|30040|30041|30042|30043|30044|30045|30046|30047|30048|30049|30050|30051|30052|30053|30054|30055|30056|30057|30058|30059|30060|30061|30062|30063|30064|30065|30066|30067" default="18" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32010]" type="action" action="RunScript(plugin.video.themoviedb.helper, authenticate_trakt)" option="close" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32013]" type="bool" id="trakt_management" default="false" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32014]" type="lsep" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32015]" type="text" id="players_url" default="" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32016]" type="action" action="RunScript(plugin.video.themoviedb.helper, update_players)" subsetting="true" option="close" enabled="!eq(-1,)" />
     </category>
 </settings>

--- a/script.py
+++ b/script.py
@@ -8,6 +8,7 @@ import xbmcgui
 import xbmcaddon
 import resources.lib.utils as utils
 from resources.lib.globals import LANGUAGES, APPEND_TO_RESPONSE
+from resources.lib import player
 from resources.lib.tmdb import TMDb
 from resources.lib.traktapi import traktAPI
 _homewindow = xbmcgui.Window(10000)
@@ -117,8 +118,8 @@ class Script:
                         self.reset_props()
             elif self.params.get('reset_path'):
                 self.reset_props()
-            elif self.params.('update_players'):
-                xbmc.log('players updated', level=xbmc.LOGNOTICE)
+            elif self.params.get('update_players'):
+                player.update_players()
             self.call_window()
 
 

--- a/script.py
+++ b/script.py
@@ -117,6 +117,8 @@ class Script:
                         self.reset_props()
             elif self.params.get('reset_path'):
                 self.reset_props()
+            elif self.params.('update_players'):
+                xbmc.log('players updated', level=xbmc.LOGNOTICE)
             self.call_window()
 
 


### PR DESCRIPTION
Using this, it is possible to input a URL to a `.zip` file containing player files, and have them extracted into the `addon_data` player file location.

A convenience of this is that it works very with [GitHub's zipball endpoint](https://developer.github.com/v3/repos/contents/#get-archive-link), which allows a URL like: `https://www.github.com/drinfernoo/json.tmdbplayers/zipball/master/` to work perfectly. The aforementioned link is to my test repo, which currently only includes the same player files that are included with this add-on, but should function as a proof-of-concept.

The `.zip` file will be extracted "flat", ignoring any folder structure contained inside, and only extract files ending in `.json`.


