### PR TITLE
Default players

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -422,3 +422,8 @@ msgstr ""
 msgctxt "#32026"
 msgid "Choose default players"
 msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32027"
+msgid "Clear default players"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -92,41 +92,6 @@ msgctxt "#30018"
 msgid "English (United States of America)"
 msgstr ""
 
-#: /resources/settings.xml
-msgctxt "#32017"
-msgid "Accounts / API Keys"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32018"
-msgid "Fanart.tv API Key"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32019"
-msgid "Fanart.tv Client Key"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32020"
-msgid "Only enter if default developer api key is deactivated"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32021"
-msgid "Use fanart.tv for additional artwork (increases load times)"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32022"
-msgid "Play / Open"
-msgstr ""
-
-#: /resources/settings.xml
-msgctxt "#32023"
-msgid "Default select action in addon"
-msgstr ""
-
 msgctxt "#30019"
 msgid "Esperanto (None)"
 msgstr ""
@@ -406,4 +371,39 @@ msgstr ""
 #: /resources/settings.xml
 msgctxt "#32016"
 msgid "Update Players from URL"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32017"
+msgid "Accounts / API Keys"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32018"
+msgid "Fanart.tv API Key"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32019"
+msgid "Fanart.tv Client Key"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32020"
+msgid "Only enter if default developer api key is deactivated"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32021"
+msgid "Use fanart.tv for additional artwork (increases load times)"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32022"
+msgid "Play / Open"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32023"
+msgid "Default select action in addon"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -407,3 +407,18 @@ msgstr ""
 msgctxt "#32023"
 msgid "Default select action in addon"
 msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32024"
+msgid "Default player for movies"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32025"
+msgid "Default player for episodes"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32026"
+msgid "Choose default players"
+msgstr ""

--- a/resources/lib/downloader.py
+++ b/resources/lib/downloader.py
@@ -107,6 +107,9 @@ class Downloader(object):
         if not response:
             xbmcgui.Dialog().ok(self.addon.getAddonInfo('name'), 'The provided URL is either invalid or inaccesible.')
             return
+            
+        if not os.path.exists(self.extract_to):
+            os.makedirs(self.extract_to)
 
         if xbmcgui.Dialog().yesno(self.addon.getAddonInfo('name'), self.msg_cleardir):
             with utils.busy_dialog():

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -25,7 +25,7 @@ def string_format_map(fmt, d):
 class Player(Plugin):
     def __init__(self):
         super(Player, self).__init__()
-        self.traktapi = traktAPI() if self.addon.getSetting('trakt_token') else None
+        self.traktapi = traktAPI()
         self.search_movie, self.search_episode, self.play_movie, self.play_episode = [], [], [], []
         self.item = defaultdict(lambda: '+')
         self.itemlist = []

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -31,6 +31,12 @@ class Player(Plugin):
         self.itemlist = []
         self.actions = []
         self.players = {}
+        
+    def setup_players(self, tmdbtype=None, details=False):
+        self.build_players(tmdbtype)
+        if details:
+            self.build_details()
+        self.build_selectbox()
 
     def play(self, itemtype, tmdb_id, season=None, episode=None):
         self.itemtype, self.tmdb_id, self.season, self.episode = itemtype, tmdb_id, season, episode
@@ -47,14 +53,26 @@ class Player(Plugin):
         if is_local:
             return True
         with utils.busy_dialog():
-            self.build_players()
-            self.build_details()
-            self.build_selectbox()
+            self.setup_players(details=True)
         if self.itemlist:
-            itemindex = xbmcgui.Dialog().select('Choose Action', self.itemlist)
+            default_player_movies = self.addon.getSetting('default_player_movies')
+            default_player_episodes = self.addon.getSetting('default_player_episodes')
+            itemindex = -1
+            
+            if (self.itemtype == 'movie' and not default_player_movies) or (self.itemtype == 'episode' and not default_player_episodes):
+                itemindex = xbmcgui.Dialog().select('Choose Action', self.itemlist)
+            else:    
+                for index in range(0, len(self.itemlist)):
+                    item = self.itemlist[index]
+                    label = item.getLabel()
+                    if (label == default_player_movies and self.itemtype == 'movie') or (label == default_player_episodes and self.itemtype == 'episode'):
+                        itemindex = index
+                        break
+                
             if itemindex > -1:
-                utils.kodi_log(self.actions[itemindex], 1)
-                xbmc.executebuiltin(self.actions[itemindex]) if sys.version_info.major == 3 else xbmc.executebuiltin(self.actions[itemindex].encode('utf-8'))
+                action = self.actions[itemindex]
+                utils.kodi_log(action, 1)
+                xbmc.executebuiltin(action) if sys.version_info.major == 3 else xbmc.executebuiltin(action.encode('utf-8'))
                 return True
 
     def build_details(self):
@@ -104,7 +122,7 @@ class Player(Plugin):
             self.item[k + '_escaped'] = v.replace(' ', '%2520')
             self.item[k + '_escaped+'] = v.replace(' ', '%252B')
 
-    def build_players(self):
+    def build_players(self, tmdbtype=None):
         basedirs = [
             'special://profile/addon_data/plugin.video.themoviedb.helper/players/',
             'special://home/addons/plugin.video.themoviedb.helper/resources/players/']
@@ -119,13 +137,16 @@ class Player(Plugin):
                     f.close()
                 if not meta.get('plugin') or not xbmc.getCondVisibility(u'System.HasAddon({0})'.format(meta.get('plugin'))):
                     continue  # Don't have plugin so skip
-                if self.tmdbtype == 'movie' and meta.get('search_movie'):
+                
+                if not tmdbtype:
+                    tmdbtype = self.tmdbtype
+                if tmdbtype == 'movie' and meta.get('search_movie'):
                     self.search_movie.append(meta.get('plugin'))
-                if self.tmdbtype == 'movie' and meta.get('play_movie'):
+                if tmdbtype == 'movie' and meta.get('play_movie'):
                     self.play_movie.append(meta.get('plugin'))
-                if self.tmdbtype == 'tv' and meta.get('search_episode'):
+                if tmdbtype == 'tv' and meta.get('search_episode'):
                     self.search_episode.append(meta.get('plugin'))
-                if self.tmdbtype == 'tv' and meta.get('play_episode'):
+                if tmdbtype == 'tv' and meta.get('play_episode'):
                     self.play_episode.append(meta.get('plugin'))
                 self.players[meta.get('plugin')] = meta
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,11 +13,14 @@
         <setting label="$ADDON[plugin.video.themoviedb.helper 32021]" type="bool" id="fanarttv_lookup" default="false" />
         <setting label="$ADDON[plugin.video.themoviedb.helper 32010]" type="action" action="RunScript(plugin.video.themoviedb.helper, authenticate_trakt)" option="close" />
         <setting label="$ADDON[plugin.video.themoviedb.helper 32013]" type="bool" id="trakt_management" default="false" />
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32013]" type="bool" id="trakt_management" default="false" />
     </category>
     <category label="$ADDON[plugin.video.themoviedb.helper 32014]">
         <setting label="$ADDON[plugin.video.themoviedb.helper 32015]" type="text" id="players_url" default="" />
-        <setting label="$ADDON[plugin.video.themoviedb.helper 32016]" type="action" action="RunScript(plugin.video.themoviedb.helper, update_players)" subsetting="true" option="close" enabled="!eq(-1,)" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32016]" type="action" action="RunScript(plugin.video.themoviedb.helper, update_players)" subsetting="true" option="close" enable="!eq(-1,)" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32026]" type="action" action="RunScript(plugin.video.themoviedb.helper, default_players)" option="close" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32024]" type="text" subsetting="true" id="default_player_movies" default="" enable="false" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32025]" type="text" subsetting="true" id="default_player_episodes" default="" enable="false" />
+        <setting label="$ADDON[plugin.video.themoviedb.helper 32027]" type="action" action="RunScript(plugin.video.themoviedb.helper, clear_defaults)" option="close" />
     </category>
     <category label="$LOCALIZE[10039]">
         <setting label="$ADDON[plugin.video.themoviedb.helper 32020]" type="lsep"/>

--- a/script.py
+++ b/script.py
@@ -72,6 +72,9 @@ class Script(Plugin):
             extract_to='special://profile/addon_data/plugin.video.themoviedb.helper/players',
             download_url=self.addon.getSetting('players_url'))
         downloader.get_extracted_zip()
+        
+    def default_players(self):
+        pass
 
     def add_path(self):
         self.position = self.position + 1
@@ -123,6 +126,8 @@ class Script(Plugin):
             traktAPI(force=True)
         elif self.params.get('update_players'):
             self.update_players()
+        elif self.params.get('default_players'):
+            self.default_players()
         elif self.params.get('add_path'):
             self.add_path()
         elif self.params.get('add_query') and self.params.get('type'):

--- a/script.py
+++ b/script.py
@@ -9,6 +9,7 @@ import resources.lib.utils as utils
 from resources.lib.downloader import Downloader
 from resources.lib.traktapi import traktAPI
 from resources.lib.plugin import Plugin
+from resources.lib.player import Player
 
 
 class Script(Plugin):
@@ -74,7 +75,19 @@ class Script(Plugin):
         downloader.get_extracted_zip()
         
     def default_players(self):
-        pass
+        movies_player = Player()
+        movies_player.setup_players(tmdbtype='movie')
+        movie_index = xbmcgui.Dialog().select('Choose Default Player for Movies', movies_player.itemlist)
+        if movie_index > -1:
+            selected = movies_player.itemlist[movie_index].getLabel()
+            self.addon.setSetting('default_player_movies', selected)
+        
+        tv_player = Player()
+        tv_player.setup_players(tmdbtype='tv')
+        tv_index = xbmcgui.Dialog().select('Choose Default Player for TV Shows', tv_player.itemlist)
+        if tv_index > -1:
+            selected = tv_player.itemlist[tv_index].getLabel()
+            self.addon.setSetting('default_player_episodes', selected)
 
     def add_path(self):
         self.position = self.position + 1

--- a/script.py
+++ b/script.py
@@ -89,6 +89,10 @@ class Script(Plugin):
             selected = tv_player.itemlist[tv_index].getLabel()
             self.addon.setSetting('default_player_episodes', selected)
 
+    def clear_defaults(self):
+        self.addon.setSetting('default_player_movies', '')
+        self.addon.setSetting('default_player_episodes', '')
+
     def add_path(self):
         self.position = self.position + 1
         self.set_props(self.position, self.params.get('add_path'))
@@ -141,6 +145,8 @@ class Script(Plugin):
             self.update_players()
         elif self.params.get('default_players'):
             self.default_players()
+        elif self.params.get('clear_defaults'):
+            self.clear_defaults()
         elif self.params.get('add_path'):
             self.add_path()
         elif self.params.get('add_query') and self.params.get('type'):


### PR DESCRIPTION
This allows for user-settable default players for each mediatype. Simply set them (from a list of applicable players) using the action in settings, and "playing" that content from the add-on will automatically attempt to use the specified player. If default players have not yet been defined, or have been cleared, the select dialog will still be shown to choose a player.