### PR TITLE
Fix bug with reused TMDb IDs

### DIFF
--- a/resources/lib/traktapi.py
+++ b/resources/lib/traktapi.py
@@ -389,7 +389,8 @@ class TraktAPI(RequestAPI):
 
     def get_traktslug(self, item_type, id_type, id_num):
         item = self.get_response_json('search', id_type, id_num, '?' + item_type)
-        return item[0].get(item_type, {}).get('ids', {}).get('slug')
+        for entry in [x for x in item if item_type in x]:
+            return entry.get(item_type, {}).get('ids', {}).get('slug')
 
     def get_collection(self, tmdbtype, page=1, limit=20):
         items = []


### PR DESCRIPTION
This will fix the instance where the played item has the same TMDb ID as another item of a different mediatype, for example:

https://www.themoviedb.org/tv/251-aqua-teen-hunger-force
https://www.themoviedb.org/movie/251-ghost

This PR makes sure that the correct item will be chosen in the process of building details for the item, including slugs, IDs, etc...