### PR TITLE
Add Embycon player

### DIFF
--- a/resources/players/embycon.json
+++ b/resources/players/embycon.json
@@ -1,0 +1,25 @@
+{
+    "name" : "EmbyCon",
+    "plugin" : "plugin.video.embycon",
+    "priority" : 200,
+    "assert": {"play_episode": ["epid"]},
+    "fallback": {"play_movie": "embycon.json search_movie",
+                 "play_episode": "embycon.json search_episode",
+                 "search_episode": "embycon.parentid.json search_episode"},
+    "play_movie" : [
+                    "plugin://plugin.video.embycon/?content_type=video&media_type=movies&mode=GET_CONTENT&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%3Dmovie%26Recursive%3Dtrue%26fields%3DMediaStreams%26ImageTypeLimit%3D1%26Years%3D{year}%26AnyProviderIdEquals%3Dtvdb.{tvdb},imdb.{imdb},tmdb.{tmdb},trakt.{trakt}",
+                    {"dialog": "auto"}
+                   ],
+    "search_movie" : [
+                    "plugin://plugin.video.embycon/?content_type=video&mode=GET_CONTENT&media_type=movies&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%movie%26IncludeMedia%3Dtrue%26filters%3DIsNotFolder%26fields%3DMediaStreams%26Recursive%3Dtrue%26Years%3D{year}%26ImageTypeLimit%3D1%26Limit%3D16%26searchTerm%3D{title_+}",
+                    {"dialog": "auto"}
+                   ],
+    "play_episode" : [
+                      "plugin://plugin.video.embycon/?content_type=video&mode=GET_CONTENT&media_type=episodes&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%3Depisode%26filters%3DIsNotFolder%26fields%3DMediaStreams%26Recursive%3Dtrue%26ImageTypeLimit%3D1%26Limit%3D16%26Years%3D{year}%26AnyProviderIdEquals%3Dtvdb.{epid}",
+                      {"dialog":"auto"}
+                    ],
+     "search_episode" : [
+                      "plugin://plugin.video.embycon/?content_type=video&mode=GET_CONTENT&media_type=episodes&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FYears%3D{year}%26IncludeItemTypes%3Depisode%26IncludeMedia%3Dtrue%26filters%3DIsNotFolder%26fields%3DMediaStreams%26Recursive%3Dtrue%26ImageTypeLimit%3D1%26MinPremiereDate%3D{premiered}T00:00:00%26MaxPremiereDate%3D{premiered}T23:59:59%26searchTerm%3D{title_escaped+}%26Limit%3D16",
+                      {"dialog":"auto"}
+                    ]
+}

--- a/resources/players/embycon.parentid.json
+++ b/resources/players/embycon.parentid.json
@@ -1,0 +1,9 @@
+{
+    "name" : "EmbyCon (by ParentID)",
+    "plugin" : "plugin.video.embycon",
+    "priority" : 200,
+    "search_episode" : [
+                      "plugin://plugin.video.embycon/?content_type=video&mode=GET_CONTENT_BY_TV_SHOW&media_type=episodes&show_ids=tvdb.{tvdb},imdb.{imdb},tmdb.{tmdb},trakt.{trakt}&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FYears%3D{year}%26IncludeItemTypes%3Depisode%26IncludeMedia%3Dtrue%26filters%3DIsNotFolder%26fields%3DMediaStreams%26Recursive%3Dtrue%26ImageTypeLimit%3D1%26Limit%3D16%26MinPremiereDate%3D{premiered}T00:00:00%26MaxPremiereDate%3D{premiered}T23:59:59",
+                      {"dialog":"auto"}
+                      ]
+}


### PR DESCRIPTION
The author of the Embycon addon just merged my changes to his branch so now the new search player that uses the TV show TVDB ID should work. 
I added an assert as well to avoid using the play_episode player when there is no TVDB ID and a fallback to try using the new method when the match by title and premiered date doesn't work. 
I added the fallback for movies as well.