### PR TITLE
add player for Composite

### DIFF
--- a/resources/players/composite_for_plex.json
+++ b/resources/players/composite_for_plex.json
@@ -1,0 +1,31 @@
+{
+    "name"              : "Composite",
+    "plugin"            : "plugin.video.composite_for_plex",
+    "priority"          : 200,
+    "assert"            : {
+                            "play_movie":       ["title", "year"],
+                            "play_episode":     ["title", "showname", "season", "episode"],
+                            "search_movie":     ["title"],
+                            "search_episode":   ["title"]
+                          },
+    "fallback"          : {
+                            "play_movie": "composite_for_plex.json search_movie",
+                            "play_episode": "composite_for_plex.json search_episode"
+                          },
+    "play_movie"        : [
+                            "plugin://plugin.video.composite_for_plex/?mode=32&video_type=movie&query={title}",
+                            {"title": "{title}", "year": "{year}"}
+                          ],
+    "play_episode"      : [
+                            "plugin://plugin.video.composite_for_plex/?mode=32&video_type=episode&query={title}",
+                            {"showtitle": "{showname}", "season": "{season}", "episode": "{episode}"}
+                          ],
+    "search_movie"      : [
+                            "plugin://plugin.video.composite_for_plex/?mode=32&video_type=movie&query={title}",
+                            {"dialog": "auto"}
+                          ],
+    "search_episode"    : [
+                            "plugin://plugin.video.composite_for_plex/?mode=32&video_type=episode&query={title}",
+                            {"dialog": "auto"}
+                          ]
+}


### PR DESCRIPTION
This requires a beta version of Composite currently. 
https://github.com/anxdpanic/plugin.video.composite_for_plex/releases/tag/1.1.0-dev

Is there a way to create a fallback player that doesn't show up in the dialog?

I'd prefer to remove the `{"dialog": "auto"}` from the search endpoints, and create a fallback player for that which doesn't show in that dialog.

Allowing custom named fallback keys could resolve it as well,
ie.
```
{
    "play_movie": "composite_for_plex.json play_movie_2",
    "play_episode": "composite_for_plex.json fb_play_episode"
}
```
