### PR TITLE
Remove year from Embycon player when a provider ID is used

### DIFF
--- a/resources/players/embycon.json
+++ b/resources/players/embycon.json
@@ -7,7 +7,7 @@
                  "play_episode": "embycon.json search_episode",
                  "search_episode": "embycon.parentid.json search_episode"},
     "play_movie" : [
-                    "plugin://plugin.video.embycon/?content_type=video&media_type=movies&mode=GET_CONTENT&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%3Dmovie%26Recursive%3Dtrue%26fields%3DMediaStreams%26ImageTypeLimit%3D1%26Years%3D{year}%26AnyProviderIdEquals%3Dtvdb.{tvdb},imdb.{imdb},tmdb.{tmdb},trakt.{trakt}",
+                    "plugin://plugin.video.embycon/?content_type=video&media_type=movies&mode=GET_CONTENT&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%3Dmovie%26Recursive%3Dtrue%26fields%3DMediaStreams%26ImageTypeLimit%3D1%26AnyProviderIdEquals%3Dtvdb.{tvdb},imdb.{imdb},tmdb.{tmdb},trakt.{trakt}",
                     {"dialog": "auto"}
                    ],
     "search_movie" : [
@@ -15,7 +15,7 @@
                     {"dialog": "auto"}
                    ],
     "play_episode" : [
-                      "plugin://plugin.video.embycon/?content_type=video&mode=GET_CONTENT&media_type=episodes&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%3Depisode%26filters%3DIsNotFolder%26fields%3DMediaStreams%26Recursive%3Dtrue%26ImageTypeLimit%3D1%26Limit%3D16%26Years%3D{year}%26AnyProviderIdEquals%3Dtvdb.{epid}",
+                      "plugin://plugin.video.embycon/?content_type=video&mode=GET_CONTENT&media_type=episodes&url=%7Bserver%7D%2Femby%2FUsers%2F%7Buserid%7D%2FItems%3FIncludeItemTypes%3Depisode%26filters%3DIsNotFolder%26fields%3DMediaStreams%26Recursive%3Dtrue%26ImageTypeLimit%3D1%26Limit%3D16%26AnyProviderIdEquals%3Dtvdb.{epid}",
                       {"dialog":"auto"}
                     ],
      "search_episode" : [


### PR DESCRIPTION
I realise that causes problems when TMDB and TVDB have different airing dates. Given an ID is provided the year shouldn't be needed in this case. 