### PR TITLE
Re-work award properties regex - Fixes #512

### DIFF
--- a/resources/lib/omdb/mapping.py
+++ b/resources/lib/omdb/mapping.py
@@ -30,7 +30,7 @@ class ItemMapper(_ItemMapper):
                 'func': lambda v: get_between_strings(v or '', 'Won ', ' Golden Globe')}, {
                 # ---
                 'keys': [('infoproperties', 'award_wins')],
-                'func': lambda v: get_between_strings(v or '', '. Another ', ' wins') or get_between_strings(v or '', '', ' wins')}, {
+                'func': lambda v: get_between_strings(v or '', '. Another ', ' win') or get_between_strings(v or '', 'Oscars. ', ' win') or get_between_strings(v or '', 'Oscar. ', ' win') or get_between_strings(v or '', '', ' win')}, {
                 # ---
                 'keys': [('infoproperties', 'oscar_nominations')],
                 'func': lambda v: get_between_strings(v or '', 'Nominated for ', ' Oscar')}, {
@@ -39,7 +39,7 @@ class ItemMapper(_ItemMapper):
                 'func': lambda v: get_between_strings(v or '', 'Nominated for ', ' Golden Globe')}, {
                 # ---
                 'keys': [('infoproperties', 'award_nominations')],
-                'func': lambda v: get_between_strings(v or '', 'wins & ', ' nominations') or get_between_strings(v or '', '', ' nominations')
+                'func': lambda v: get_between_strings(v or '', 'wins & ', ' nomination') or get_between_strings(v or '', 'win & ', ' nomination') or get_between_strings(v or '', '', ' nomination')
             }],
             'tomatoReviews': [{
                 'keys': [('infoproperties', 'rottentomatoes_reviewstotal')],


### PR DESCRIPTION
This fixes #512 - regex issues with award properties for some movies:

The Shawshank Redemption (before): https://i.imgur.com/utpnOs2.png
The Shawshank Redemption (after): https://i.imgur.com/TlUhfvA.png

Cinema Paradiso (before): https://i.imgur.com/Cbf8nlh.png
Cinema Paradiso (after): https://i.imgur.com/7DRsidW.png

Mortal Kombat (before): https://i.imgur.com/XZd0dIQ.png
Mortal Kombat (after): https://i.imgur.com/Tr8Pwki.png

Vanquish (before): https://i.imgur.com/ZkB1Zd0.png
Vanquish (after): https://i.imgur.com/OXMqQHw.png

Bloodshot (before): https://i.imgur.com/MUYM2Kk.png
Bloodshot (after): https://i.imgur.com/ZsK5OHy.png

Greenland (before): https://i.imgur.com/BewiL5f.png
Greenland (after): https://i.imgur.com/t9cRUaA.png

Greyhound (before): https://i.imgur.com/b8am6LP.png
Greyhound (after): https://i.imgur.com/zMqOou9.png

Secondary question: I have some ListItem.Property() that is probably stored in OMDB.db cache. Will I have to wipe this db to see the fixed award properties? As checking out this PR does fix Service Monitor properties but not stored properties.