### PR TITLE
new option in artwork quality setting for TMDb

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2027,11 +2027,6 @@ msgid "Retrieve season specific artwork"
 msgstr ""
 
 #: /resources/settings.xml
-msgctxt "#32397"
-msgid "Original"
-msgstr ""
-
-#: /resources/settings.xml
 msgctxt "#32400"
 msgid "Play local Kodi library files"
 msgstr ""
@@ -2069,6 +2064,26 @@ msgstr ""
 #: /resources/settings.xml
 msgctxt "#32407"
 msgid "Get resume points from Trakt (increases load times)"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32408"
+msgid "Original"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32409"
+msgid "Very High"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32410"
+msgid "Medium"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32411"
+msgid "Very Low"
 msgstr ""
 
 msgctxt "#30030"

--- a/resources/lib/addon/constants.py
+++ b/resources/lib/addon/constants.py
@@ -30,10 +30,11 @@ IMAGEPATH_ORIGINAL = 'https://image.tmdb.org/t/p/original'
 IMAGEPATH_HIGH = 'https://image.tmdb.org/t/p/w1280'
 IMAGEPATH_LOW = 'https://image.tmdb.org/t/p/w780'
 
+IMAGEPATH_BIGPOSTER = 'https://image.tmdb.org/t/p/w780'
 IMAGEPATH_POSTER = 'https://image.tmdb.org/t/p/w500'
 IMAGEPATH_SMALLPOSTER = 'https://image.tmdb.org/t/p/w342'
 
-ARTWORK_BLACKLIST = [[], ['poster'], ['fanart', 'poster']]
+ARTWORK_BLACKLIST = [[], ['fanart'], ['fanart', 'poster'], ['fanart', 'poster'], ['fanart', 'poster'], ['fanart', 'poster']]
 
 TMDB_GENRE_IDS = {
     "Action": 28, "Adventure": 12, "Action & Adventure": 10759, "Animation": 16, "Comedy": 35, "Crime": 80, "Documentary": 99, "Drama": 18,

--- a/resources/lib/tmdb/mapping.py
+++ b/resources/lib/tmdb/mapping.py
@@ -3,14 +3,14 @@ from resources.lib.addon.plugin import get_mpaa_prefix, get_language, convert_ty
 from resources.lib.addon.parser import try_int, try_float
 from resources.lib.addon.setutils import ITER_PROPS_MAX, iter_props, dict_to_list, get_params
 from resources.lib.addon.timedate import format_date, age_difference
-from resources.lib.addon.constants import IMAGEPATH_ORIGINAL, IMAGEPATH_HIGH, IMAGEPATH_LOW, IMAGEPATH_POSTER, IMAGEPATH_SMALLPOSTER, TMDB_GENRE_IDS
+from resources.lib.addon.constants import IMAGEPATH_ORIGINAL, IMAGEPATH_HIGH, IMAGEPATH_LOW, IMAGEPATH_BIGPOSTER, IMAGEPATH_POSTER, IMAGEPATH_SMALLPOSTER, TMDB_GENRE_IDS
 from resources.lib.api.mapping import UPDATE_BASEKEY, _ItemMapper, get_empty_item
 
 
 ADDON = xbmcaddon.Addon('plugin.video.themoviedb.helper')
 ARTWORK_QUALITY = ADDON.getSettingInt('artwork_quality')
-ARTWORK_QUALITY_POSTER = [IMAGEPATH_POSTER, IMAGEPATH_POSTER, IMAGEPATH_SMALLPOSTER][ARTWORK_QUALITY]
-ARTWORK_QUALITY_FANART = [IMAGEPATH_ORIGINAL, IMAGEPATH_HIGH, IMAGEPATH_LOW][ARTWORK_QUALITY]
+ARTWORK_QUALITY_POSTER = [IMAGEPATH_ORIGINAL, IMAGEPATH_BIGPOSTER, IMAGEPATH_BIGPOSTER, IMAGEPATH_POSTER, IMAGEPATH_SMALLPOSTER, IMAGEPATH_SMALLPOSTER][ARTWORK_QUALITY]
+ARTWORK_QUALITY_FANART = [IMAGEPATH_ORIGINAL, IMAGEPATH_HIGH, IMAGEPATH_HIGH, IMAGEPATH_HIGH, IMAGEPATH_HIGH, IMAGEPATH_LOW][ARTWORK_QUALITY]
 
 
 def get_imagepath_poster(v):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,7 +8,7 @@
         <setting label="$ADDON[plugin.video.themoviedb.helper 32038]" type="bool" id="local_db" default="false" />
         <setting label="$ADDON[plugin.video.themoviedb.helper 32401]" type="lsep"/>
         <setting label="$ADDON[plugin.video.themoviedb.helper 32402]" type="bool" id="tmdb_details" default="false" />
-        <setting label="TMDb artwork quality" type="enum" id="artwork_quality" lvalues="32397|419|418" default="0" />
+        <setting label="TMDb artwork quality" type="enum" id="artwork_quality" lvalues="32408|32409|419|32410|418|32411" default="0" />
     </category>
     <category label="$ADDON[plugin.video.themoviedb.helper 32088]">
         <setting label="$ADDON[plugin.video.themoviedb.helper 32089]" type="lsep"/>


### PR DESCRIPTION
I added a few new options. Now we have:

Original
Uses highest quality available.
Prefers fanart.tv artwork (if enabled and available)

Very High
Uses W1280 fanart from TMDb
Prefers fanart.tv for all other artwork types (if enabled and available)

High
Uses W1280 fanart and W780 posters from TMDb
Prefers fanart.tv for all other artwork types (if enabled and available)

Medium
Uses W1280 fanart and W500 posters from TMDb
Prefers fanart.tv for all other artwork types (if enabled and available)

Low
Uses W1280 fanart and W342 posters from TMDb
Prefers fanart.tv for all other artwork types (if enabled and available)

very Low
Uses W780 fanart and W342 posters from TMDb
Prefers fanart.tv for all other artwork types (if enabled and available)