### PR TITLE
Create dispatch_to_repo.yml

### DIFF
--- a/.github/workflows/dispatch_to_repo.yml
+++ b/.github/workflows/dispatch_to_repo.yml
@@ -1,0 +1,21 @@
+name: Dispatch to Repo
+on: 
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+    
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ["jurialmunkey/repository.jurialmunkey"]
+    steps:
+      - name: Push to repo
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: update
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "module": "jurialmunkey/plugin.video.themoviedb.helper", "tag": "${{ github.ref_name }}"}'


### PR DESCRIPTION
This allows this repository to dispatch to [repository.jurialmunkey](https://github.com/jurialmunkey/repository.jurialmunkey) whenever a tagged release is created.

This workflow requires that a personal access token be setup, as described [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token), and that it be added as a repository secret (named `TOKEN`), as described [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).

This works in tandem with https://github.com/jurialmunkey/repository.jurialmunkey/pull/29.