### PR TITLE
Syntax typo

### DIFF
--- a/resources/lib/monitor/listitem.py
+++ b/resources/lib/monitor/listitem.py
@@ -390,7 +390,7 @@ class ListItemMonitor(CommonMonitorFunctions):
         container_id = container_id or int(get_infolabel('Skin.String(TMDbHelper.MonitorContainer)') or 0)
         if not window_id or not container_id:
             return
-        if not get_condvisibility(f'Control.IsVisible({container_id}'):
+        if not get_condvisibility(f'Control.IsVisible({container_id})'):
             return -1
         return container_id
 


### PR DESCRIPTION
Caused issues (at least) in rapid scrolling of PVR guide.

Had found this error in kodi log:

2022-09-29 17:09:19.675 T:7715    ERROR <general>: unmatched parentheses in control.isvisible(99950

Then searched all code for addons I have installed, and located this line.

I have tested this change, and now rapid scrolling in PVR guide seems to be fixed :-)