### PR TITLE
Add JellyCon player

### DIFF
--- a/resources/players/jellycon.json
+++ b/resources/players/jellycon.json
@@ -1,0 +1,26 @@
+{
+    "name" : "JellyCon",
+    "plugin" : "plugin.video.jellycon",
+    "priority" : 200,
+    "is_resolvable": "true",
+    "assert": {"play_episode": ["epid"]},
+    "fallback": {"play_movie": "jellycon.json search_movie",
+                 "play_episode": "jellycon.json search_episode",
+                 "search_episode": "jellycon.parentid.json search_episode"},
+    "play_movie" : [
+        "plugin://plugin.video.jellycon/?content_type=video&mode=NEW_SEARCH&item_type=Movie&query={title}",
+        {"dialog": "auto"}
+     ],
+    "search_movie" : [
+        "plugin://plugin.video.jellycon/?content_type=video&mode=NEW_SEARCH&item_type=Movie&query={title}",
+        {"dialog": "auto"}
+     ],
+    "play_episode" : [
+        "plugin://plugin.video.jellycon/?content_type=video&mode=NEW_SEARCH&item_type=Episode&query={title}",
+        {"dialog":"auto"}
+     ],
+     "search_episode" : [
+        "plugin://plugin.video.jellycon/?content_type=video&mode=NEW_SEARCH&item_type=Episode&query={title}",
+        {"dialog":"auto"}
+     ]
+}

--- a/resources/players/jellycon.parentid.json
+++ b/resources/players/jellycon.parentid.json
@@ -1,0 +1,9 @@
+{
+    "name" : "JellyCon (by show name)",
+    "plugin" : "plugin.video.jellycon",
+    "priority" : 200,
+    "search_episode" : [
+        "plugin://plugin.video.jellycon/?content_type=video&mode=NEW_SEARCH&item_type=series&query={showname}",
+        {"dialog":"auto"}
+    ]
+}


### PR DESCRIPTION
Adds JellyCon as a playback source.  Tested on one of my servers with movies and episodes.  Honestly not super sure what benefit the parent ID one is unless the search for an actual episode fails, but I largely copied the existing EmbyCon functionality and updated it to work with our addon.

Should fix https://github.com/jellyfin/jellycon/issues/214