### PR TITLE
Allow play_using parameter to refer to addon name

### DIFF
--- a/resources/lib/items/router.py
+++ b/resources/lib/items/router.py
@@ -39,7 +39,11 @@ class Router():
         return container.get_directory(items_only, build_items)
 
     def run(self):
-        if self.params.get('info') == 'play':
+        mode = self.params.get('mode') or self.params.get('info')
+        player = self.params.get('player') or self.params.get('play_using')
+        if mode == 'play' or player:
+            self.params['mode'] = mode
+            self.params['player'] = player
             return self.play_external()
         if self.params.get('info') == 'related':
             return self.context_related()

--- a/resources/lib/items/router.py
+++ b/resources/lib/items/router.py
@@ -39,11 +39,7 @@ class Router():
         return container.get_directory(items_only, build_items)
 
     def run(self):
-        mode = self.params.get('mode') or self.params.get('info')
-        player = self.params.get('player') or self.params.get('play_using')
-        if mode == 'play' or player:
-            self.params['mode'] = mode
-            self.params['player'] = player
+        if self.params.get('info') == 'play':
             return self.play_external()
         if self.params.get('info') == 'related':
             return self.context_related()

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -17,7 +17,6 @@ from resources.lib.player.putils import get_players_from_file, make_playlist, ma
 from resources.lib.files.futils import get_json_filecache
 from resources.lib.addon.logger import kodi_log
 from threading import Thread
-from unicodedata import normalize as u_normalize
 
 
 def string_format_map(fmt, d):
@@ -163,7 +162,7 @@ class Players(object):
                     priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
                 player['is_provider'] = False    
             player['priority'] = priority
-            return priority, u_normalize('NFKD', player.get('name', '\uFFFF')).lower()
+            return priority, player.get('plugin', '\uFFFF').lower()
 
         players = sorted(self.players.items(), key=_set_priority)
         return players

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -174,10 +174,12 @@ class Players(object):
         if value:
             file = player_id
         else:
-            file, value = next(
-                ((file, value) for file, value in self.players.items() if value.get('plugin') == player_id),
-                (player_id, {})
-            )
+            for file, value in self.players.items():
+                if value.get('plugin') == player_id:
+                    break
+            else:
+                file = player_id
+                value = {}
         if mode in ['play_movie', 'play_episode']:
             name = get_localized(32061)
             is_folder = False

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -146,16 +146,17 @@ class Players(object):
 
     def _get_prioritised_players(self):
         try:
-            providers = self.details.infoproperties.get('providers', '')
+            providers = self.details.infoproperties.get('providers')
+            if providers:
+                providers = providers.split(' / ')
         except AttributeError:
-            providers = ''
-        providers = tuple(providers.split(' / '))
+            providers = None
 
-        def _set_priority(item, _providers=providers):
+        def _set_priority(item):
             file, player = item
-            player_provider = player.get('provider') or None
-            if player_provider in _providers:
-                priority = _providers.index(player_provider) + 1  # Add 1 because sorted() puts 0 index last
+            player_provider = providers and player.get('provider')
+            if player_provider and player_provider in providers:
+                priority = providers.index(player_provider) + 1  # Add 1 because sorted() puts 0 index last
                 player['is_provider'] = True
             else:
                 if player.get('is_provider', True):

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -158,7 +158,9 @@ class Players(object):
                 priority = _providers.index(player_provider) + 1  # Add 1 because sorted() puts 0 index last
                 player['is_provider'] = True
             else:
-                priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
+                if player.get('is_provider', True):
+                    priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
+                player['is_provider'] = False    
             player['priority'] = priority
             return priority
 

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -17,6 +17,7 @@ from resources.lib.player.putils import get_players_from_file, make_playlist, ma
 from resources.lib.files.futils import get_json_filecache
 from resources.lib.addon.logger import kodi_log
 from threading import Thread
+from unicodedata import normalize as u_normalize
 
 
 def string_format_map(fmt, d):
@@ -162,7 +163,7 @@ class Players(object):
                     priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
                 player['is_provider'] = False    
             player['priority'] = priority
-            return priority, player.get('name', '\uFFFF').lower()
+            return priority, u_normalize('NFKD', player.get('name', '\uFFFF')).lower()
 
         players = sorted(self.players.items(), key=_set_priority)
         return players

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -153,14 +153,14 @@ class Players(object):
 
         def _set_priority(item, _providers=providers):
             file, player = item
-            player_provider = player.get('provider')
+            player_provider = player.get('provider') or None
             if player_provider in _providers:
                 priority = _providers.index(player_provider) + 1  # Add 1 because sorted() puts 0 index last
                 player['is_provider'] = True
             else:
                 if player.get('is_provider', True):
                     priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
-                player['is_provider'] = False    
+                player['is_provider'] = False
             player['priority'] = priority
             return priority, player.get('plugin', '\uFFFF').lower()
 

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -162,7 +162,7 @@ class Players(object):
                     priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
                 player['is_provider'] = False    
             player['priority'] = priority
-            return priority
+            return priority, player.get('name', '\uFFFF').lower()
 
         players = sorted(self.players.items(), key=_set_priority)
         return players

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -169,16 +169,15 @@ class Players(object):
                     return False  # Key didn't have a value so player fails assert check
         return True  # Player passed the assert check
 
-    def _get_built_player(self, file, mode, value=None):
-        value = value or self.players.get(file) or {}
-        if not value:
-            plugin_name = file
-            plugin_players = [
-                (file, player) for file, player in self.players.items()
-                if player['plugin'] == plugin_name
-            ]
-            if plugin_players:
-                file, value = plugin_players[0]
+    def _get_built_player(self, player_id, mode, value=None):
+        value = value or self.players.get(player_id)
+        if value:
+            file = player_id
+        else:
+            file, value = next(
+                ((file, value) for file, value in self.players.items() if value.get('plugin') == player_id),
+                (player_id, {})
+            )
         if mode in ['play_movie', 'play_episode']:
             name = get_localized(32061)
             is_folder = False
@@ -262,14 +261,14 @@ class Players(object):
                 continue  # Skip disabled players
             if tmdb_type == 'movie':
                 if v.get('play_movie') and self._check_assert(v.get('assert', {}).get('play_movie', [])):
-                    dialog_play.append(self._get_built_player(file=k, mode='play_movie', value=v))
+                    dialog_play.append(self._get_built_player(player_id=k, mode='play_movie', value=v))
                 if v.get('search_movie') and self._check_assert(v.get('assert', {}).get('search_movie', [])):
-                    dialog_search.append(self._get_built_player(file=k, mode='search_movie', value=v))
+                    dialog_search.append(self._get_built_player(player_id=k, mode='search_movie', value=v))
             else:
                 if v.get('play_episode') and self._check_assert(v.get('assert', {}).get('play_episode', [])):
-                    dialog_play.append(self._get_built_player(file=k, mode='play_episode', value=v))
+                    dialog_play.append(self._get_built_player(player_id=k, mode='play_episode', value=v))
                 if v.get('search_episode') and self._check_assert(v.get('assert', {}).get('search_episode', [])):
-                    dialog_search.append(self._get_built_player(file=k, mode='search_episode', value=v))
+                    dialog_search.append(self._get_built_player(player_id=k, mode='search_episode', value=v))
         return dialog_play + dialog_search
 
     def select_player(self, detailed=True, clear_player=False, header=get_localized(32042), combined=False):
@@ -334,10 +333,10 @@ class Players(object):
     def _get_player_or_fallback(self, fallback):
         if not fallback:
             return
-        file, mode = fallback.split()
-        if not file or not mode:
+        player_id, mode = fallback.split()
+        if not player_id or not mode:
             return
-        player = self._get_built_player(file, mode)
+        player = self._get_built_player(player_id, mode)
         if not player:
             return
 

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -171,6 +171,14 @@ class Players(object):
 
     def _get_built_player(self, file, mode, value=None):
         value = value or self.players.get(file) or {}
+        if not value:
+            plugin_name = file
+            plugin_players = [
+                (file, player) for file, player in self.players.items()
+                if player['plugin'] == plugin_name
+            ]
+            if plugin_players:
+                file, value = plugin_players[0]
         if mode in ['play_movie', 'play_episode']:
             name = get_localized(32061)
             is_folder = False

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -99,7 +99,7 @@ class Players(object):
             self.item = set_detailed_item(tmdb_type, tmdb_id, season, episode, details=self.details) or {}
 
             _p_dialog.update(f'{get_localized(32376)}...')
-            self.players_prioritised = self._set_provider_priority()
+            self.players_prioritised = self._get_prioritised_players()
             self.playerstring = get_playerstring(tmdb_type, tmdb_id, season, episode, details=self.details)
             self.dialog_players = self._get_players_for_dialog(tmdb_type)
 
@@ -144,7 +144,7 @@ class Players(object):
             details.set_details(details=self.details_ext_ids, reverse=True)
         return set_detailed_item(tmdb_type, tmdb_id, season, episode, details=details) or {}
 
-    def _set_provider_priority(self):
+    def _get_prioritised_players(self):
         try:
             providers = self.details.infoproperties.get('providers', '')
         except AttributeError:

--- a/resources/lib/player/players.py
+++ b/resources/lib/player/players.py
@@ -99,7 +99,7 @@ class Players(object):
             self.item = set_detailed_item(tmdb_type, tmdb_id, season, episode, details=self.details) or {}
 
             _p_dialog.update(f'{get_localized(32376)}...')
-            self._set_provider_priority()
+            self.players_prioritised = self._set_provider_priority()
             self.playerstring = get_playerstring(tmdb_type, tmdb_id, season, episode, details=self.details)
             self.dialog_players = self._get_players_for_dialog(tmdb_type)
 
@@ -145,17 +145,25 @@ class Players(object):
         return set_detailed_item(tmdb_type, tmdb_id, season, episode, details=details) or {}
 
     def _set_provider_priority(self):
-        try:  # Check if players are listed in providers and bump priority if found
-            providers = self.details.infoproperties['providers']
-            providers = providers.split(' / ')
-            for k, v in self.players.items():
-                if 'provider' not in v or v['provider'] not in providers:
-                    v['priority'] = v.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
-                    continue
-                v['priority'] = providers.index(v['provider']) + 1  # Add 1 because sorted() puts 0 index last
-                v['is_provider'] = True
-        except (KeyError, AttributeError):
-            pass
+        try:
+            providers = self.details.infoproperties.get('providers', '')
+        except AttributeError:
+            providers = ''
+        providers = tuple(providers.split(' / '))
+
+        def _set_priority(item, _providers=providers):
+            file, player = item
+            player_provider = player.get('provider')
+            if player_provider in _providers:
+                priority = _providers.index(player_provider) + 1  # Add 1 because sorted() puts 0 index last
+                player['is_provider'] = True
+            else:
+                priority = player.get('priority', PLAYERS_PRIORITY) + 100  # Increase priority baseline by 100 to prevent other players displaying above providers
+            player['priority'] = priority
+            return priority
+
+        players = sorted(self.players.items(), key=_set_priority)
+        return players
 
     def _check_assert(self, keys=[]):
         if not self.item:
@@ -169,17 +177,19 @@ class Players(object):
                     return False  # Key didn't have a value so player fails assert check
         return True  # Player passed the assert check
 
-    def _get_built_player(self, player_id, mode, value=None):
-        value = value or self.players.get(player_id)
-        if value:
+    def _get_built_player(self, player_id, mode, player=None):
+        player = player or self.players.get(player_id)
+        if player:
             file = player_id
         else:
-            for file, value in self.players.items():
-                if value.get('plugin') == player_id:
+            for file, player in self.players_prioritised:
+                if mode not in player:
+                    continue
+                if player_id in (player.get('plugin'), player.get('provider'), player.get('name')):
                     break
             else:
                 file = player_id
-                value = {}
+                player = {}
         if mode in ['play_movie', 'play_episode']:
             name = get_localized(32061)
             is_folder = False
@@ -189,17 +199,17 @@ class Players(object):
         return {
             'file': file, 'mode': mode,
             'is_folder': is_folder,
-            'is_provider': value.get('is_provider') if not is_folder else False,
-            'is_resolvable': value.get('is_resolvable'),
-            'requires_ids': value.get('requires_ids', False),
-            'make_playlist': value.get('make_playlist'),
-            'api_language': value.get('api_language'),
-            'language': value.get('language'),
-            'name': f'{name} {value.get("name")}',
-            'plugin_name': value.get('plugin'),
-            'plugin_icon': value.get('icon', '').format(ADDONPATH) or KodiAddon(value.get('plugin', '')).getAddonInfo('icon'),
-            'fallback': value.get('fallback', {}).get(mode),
-            'actions': value.get(mode)}
+            'is_provider': player.get('is_provider') if not is_folder else False,
+            'is_resolvable': player.get('is_resolvable'),
+            'requires_ids': player.get('requires_ids', False),
+            'make_playlist': player.get('make_playlist'),
+            'api_language': player.get('api_language'),
+            'language': player.get('language'),
+            'name': f'{name} {player.get("name")}',
+            'plugin_name': player.get('plugin'),
+            'plugin_icon': player.get('icon', '').format(ADDONPATH) or KodiAddon(player.get('plugin', '')).getAddonInfo('icon'),
+            'fallback': player.get('fallback', {}).get(mode),
+            'actions': player.get(mode)}
 
     def _get_local_item(self, tmdb_type):
         if not get_setting('default_player_kodi', 'int'):
@@ -257,20 +267,19 @@ class Players(object):
             return []
         dialog_play = self._get_local_item(tmdb_type)
         dialog_search = []
-        items = sorted(self.players.items(), key=lambda i: int(i[1].get('priority') or 0) or PLAYERS_PRIORITY)
-        for k, v in items:
-            if v.get('disabled', '').lower() == 'true':
+        for file, player in self.players_prioritised:
+            if player.get('disabled', '').lower() == 'true':
                 continue  # Skip disabled players
             if tmdb_type == 'movie':
-                if v.get('play_movie') and self._check_assert(v.get('assert', {}).get('play_movie', [])):
-                    dialog_play.append(self._get_built_player(player_id=k, mode='play_movie', value=v))
-                if v.get('search_movie') and self._check_assert(v.get('assert', {}).get('search_movie', [])):
-                    dialog_search.append(self._get_built_player(player_id=k, mode='search_movie', value=v))
+                if player.get('play_movie') and self._check_assert(player.get('assert', {}).get('play_movie', [])):
+                    dialog_play.append(self._get_built_player(player_id=file, mode='play_movie', player=player))
+                if player.get('search_movie') and self._check_assert(player.get('assert', {}).get('search_movie', [])):
+                    dialog_search.append(self._get_built_player(player_id=file, mode='search_movie', player=player))
             else:
-                if v.get('play_episode') and self._check_assert(v.get('assert', {}).get('play_episode', [])):
-                    dialog_play.append(self._get_built_player(player_id=k, mode='play_episode', value=v))
-                if v.get('search_episode') and self._check_assert(v.get('assert', {}).get('search_episode', [])):
-                    dialog_search.append(self._get_built_player(player_id=k, mode='search_episode', value=v))
+                if player.get('play_episode') and self._check_assert(player.get('assert', {}).get('play_episode', [])):
+                    dialog_play.append(self._get_built_player(player_id=file, mode='play_episode', player=player))
+                if player.get('search_episode') and self._check_assert(player.get('assert', {}).get('search_episode', [])):
+                    dialog_search.append(self._get_built_player(player_id=file, mode='search_episode', player=player))
         return dialog_play + dialog_search
 
     def select_player(self, detailed=True, clear_player=False, header=get_localized(32042), combined=False):


### PR DESCRIPTION
I would like to be able to call TMDb Helper players, without actually knowing the filename of the player json file, but instead based on the name of the plugin that is used as the plugin ID in the player file.

This PR is the simplest way I could figure out how to do that, and just searches the list of players to match the first player whose plugin ID is equal to the value of the play_using parameter, if a filename match is not already found.