### PR TITLE
Don't call getUniqueID if function not defined

### DIFF
--- a/resources/lib/monitor/player.py
+++ b/resources/lib/monitor/player.py
@@ -69,8 +69,11 @@ class PlayerMonitor(Player, CommonMonitorFunctions):
         self.epyear = info_tag.getYear() if self.dbtype == 'episode' else None
         self.season = info_tag.getSeason() if self.dbtype == 'episode' else None
         self.episode = info_tag.getEpisode() if self.dbtype == 'episode' else None
-        self.tmdb_id = info_tag.getUniqueID('tmdb')
-        self.tmdb_id = self.get_tmdb_id_parent(self.tmdb_id, 'episode') if self.dbtype == 'episode' else self.tmdb_id
+        if hasattr(self, "getUniqueID"):
+            self.tmdb_id = info_tag.getUniqueID('tmdb')
+            self.tmdb_id = self.get_tmdb_id_parent(self.tmdb_id, 'episode') if self.dbtype == 'episode' else self.tmdb_id
+        else:
+            self.tmdb_id = None
 
         self.current_item = (self.total_time, self.dbtype, self.dbid, self.imdb_id, self.query, self.year, self.epyear, self.season, self.episode, )
         if self.previous_item and self.current_item == self.previous_item:


### PR DESCRIPTION
Older versions of Kodi (Matrix and older) do not have a defined function
called getUniqueID for video tags.

This checks whether the function exists, and otherwise sets the tmdb_id
to None, which will then revert to the old behaviour later.

This fixes the issue in Arctic Horizon 2, where clearlogo isn't populating during playback. It is a bit of a hacky fix, though.