### PR TITLE
Option to separete Trakt lists into folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 .idea/
 
 *.zip
+/.vs/plugin.video.themoviedb.helper/FileContentIndex
+/.vs/plugin.video.themoviedb.helper/v17
+/.vs

--- a/addon.xml
+++ b/addon.xml
@@ -10,7 +10,7 @@ provider-name="jurialmunkey">
   <import addon="script.module.addon.signals" version="0.0.6" />
   <import addon="script.module.tmdbhelper" version="0.0.8" />
   <import addon="script.module.infotagger" version="0.0.5" />
-  <import addon="script.module.beautifulsoup4" version="4.9.3" />
+  <import addon="script.module.beautifulsoup4" version="4.9.3" />  
 </requires>
 <extension point="xbmc.python.pluginsource" library="resources/plugin.py">
   <provides>video</provides>

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2782,3 +2782,8 @@ msgstr ""
 msgctxt "#32027"
 msgid "Clear default players"
 msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32490"
+msgid "Separate Trakt list(s) into folder(s)"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -334,6 +334,16 @@
                         <data>RunScript(plugin.video.themoviedb.helper,monitor_userlist)</data>
                     </control>
                 </setting>
+                <setting id="trakt_list_folders" type="boolean" label="32490" help="" parent="library_autoupdate">
+                    <level>0</level>
+                    <default>false</default>
+                    <dependencies>
+                        <dependency type="enable">
+                            <condition operator="is" setting="library_autoupdate">True</condition>
+                        </dependency>
+                    </dependencies>                    
+                    <control type="toggle"/>                    
+                </setting>
                 <setting id="monitor_userslug" type="string" help="">
                     <level>0</level>
                     <default/>

--- a/resources/tmdbhelper/lib/script/router.py
+++ b/resources/tmdbhelper/lib/script/router.py
@@ -28,7 +28,7 @@ class Script(object):
             else:
                 self.params[arg] = True
         self.params = reconfigure_legacy_params(**self.params)
-
+      
     routing_table = {
         'authenticate_trakt':
             lambda **kwargs: importmodule('tmdbhelper.lib.api.trakt.api', 'TraktAPI')(force=True),
@@ -114,7 +114,7 @@ class Script(object):
             lambda **kwargs: importmodule('tmdbhelper.lib.monitor.service', 'restart_service_monitor')()
     }
 
-    def router(self):
+    def router(self):        
         if not self.params:
             return
         routes_available = set(self.routing_table.keys())

--- a/resources/tmdbhelper/lib/script/sync.py
+++ b/resources/tmdbhelper/lib/script/sync.py
@@ -299,7 +299,7 @@ class _UserList():
             return
         if confirm and not Dialog().yesno(get_localized(20444), get_localized(32362)):
             return
-        add_to_library(tmdb_type, tmdb_id=tmdb_id)
+        add_to_library(tmdb_type, tmdb_id=tmdb_id, list_slug=slug[0], user_slug=slug[1])
 
     def sync(self):
         """ Entry point """

--- a/resources/tmdbhelper/lib/update/update.py
+++ b/resources/tmdbhelper/lib/update/update.py
@@ -103,7 +103,7 @@ def create_nfo(tmdb_type, tmdb_id, *args, **kwargs):
     create_file(content, filename, *args, **kwargs)
 
 
-def create_playlist(items, dbtype, user_slug, list_slug):
+def create_playlist(items, dbtype, user_slug, list_slug, traktlist_dir):
     """ Creates a smart playlist from a list of titles """
     filename = f'{user_slug}-{list_slug}-{dbtype}'
     filepath = u'special://profile/playlists/video/'
@@ -111,8 +111,15 @@ def create_playlist(items, dbtype, user_slug, list_slug):
     fcontent.append(f'<smartplaylist type="{dbtype}">')
     fcontent.append(f'    <name>{list_slug} by {user_slug} ({dbtype})</name>')
     fcontent.append(u'    <match>any</match>')
-    for i in items:
-        fcontent.append(f'    <rule field="{i[0]}" operator="is"><value>{i[1]}</value></rule>')
+    if get_setting('trakt_list_folders'):
+        if dbtype == 'tvshows': BASEDIR = BASEDIR_TV
+        else: BASEDIR = BASEDIR_MOVIE
+        fcontent.append(u'    <rule field="path" operator="contains">')
+        fcontent.append(f'        <value>{BASEDIR}{traktlist_dir}</value>')
+        fcontent.append(u'    </rule>')
+    else:        
+        for i in items:
+            fcontent.append(f'    <rule field="{i[0]}" operator="is"><value>{i[1]}</value></rule>')
     fcontent.append(u'</smartplaylist>')
     create_file(u'\n'.join(fcontent), filename, basedir=filepath, file_ext='xsp', clean_url=False)
 


### PR DESCRIPTION
Hi Jurialmunkey,

First of all, thank you so much for all the amazing work you have done for the Kodi community. 

I am submitting this pull request because I am facing the following issue. I have three Trakt Lists arranged into "movies & tv shows", "animes & cartoons", and "documentaries", of which each of them is pretty long, with more than 1000 items each.

But,  I've found that the current way TMDB Helper is managing Trakt Lists through creating a smart playlist for each list and setting a rule individually for each str. file, at least here in my Nvidia Shield, it takes quite a long time every time I open the playlist (Node editor).

However, when we have the Lists separated into folders, the smart playlist rule, path based, is much easier for Kodi to handle. Therefore, when we try to open it, the list opens instantly.

I am not a programmer,  and I cannot understand most of your code, LoL. So I am not 100% sure of what I wrote. Feel free to rewrite whatever you want. You can also ask me to fix it, no problem at all.

Even if you don't agree with this PR, I kindly ask you to consider implementing this feature (trakt list into folders), this would be, IMO, a huge improvement for the users who uses trakt lists  and TMDB Helper to manage Kodi library. 

PS: I used the v5.1.8 because I couldn't find the file "jurialmunkey" for the logger in the v5.1.15 

Thank you 