### PR TITLE
Support of external paths like SMB and NFS for image cache location

### DIFF
--- a/resources/tmdbhelper/lib/monitor/images.py
+++ b/resources/tmdbhelper/lib/monitor/images.py
@@ -1,4 +1,5 @@
 import os
+import io
 import xbmcvfs
 import colorsys
 import hashlib
@@ -34,7 +35,9 @@ def _imageopen(image):
     global Image
     if Image is None:
         from PIL import Image
-    return Image.open(image)
+    with xbmcvfs.File(image, 'rb') as f:
+        image_bytes = f.readBytes()
+    return Image.open(io.BytesIO(image_bytes))
 
 
 def _closeimage(image, targetfile=None):


### PR DESCRIPTION
More details provided in issue https://github.com/jurialmunkey/plugin.video.themoviedb.helper/issues/1203
When using external paths like SMB or NFS in image cache location, pillow module fails to read the files. Using xbmcvfs instead to read files from remote paths seems to work fine. 