### PR TITLE
Add TV show title to episode labels for improved readability

### DIFF
--- a/resources/tmdbhelper/lib/items/listitem.py
+++ b/resources/tmdbhelper/lib/items/listitem.py
@@ -446,11 +446,17 @@ class _Episode(_Tvshow):
             return
         self._set_params_reroute_default()
 
-    def set_episode_label(self, format_label=u'{season}x{episode:0>2}. {label}'):
+    def set_episode_label(self, format_label=u'{show_title} - {season}x{episode:0>2}. {label}'):
         if self.infoproperties.pop('no_label_formatting', None):
             return
         season = try_int(self.infolabels.get('season', 0))
         episode = try_int(self.infolabels.get('episode', 0))
         if not episode:
             return
-        self.label = format_label.format(season=season, episode=episode, label=self.infolabels.get('title', ''))
+        show_title = self.infolabels.get('tvshowtitle', '')  # Retrieve the show's title
+        self.label = format_label.format(
+            show_title=show_title,
+            season=season,
+            episode=episode,
+            label=self.infolabels.get('title', '')
+        )


### PR DESCRIPTION
Previously, episode labels only displayed the episode title, which could be ambiguous—especially for generic titles like "Episode 1" or "Episode 2." Even for more descriptive episode titles, it was difficult to identify the associated TV show. By including the TV show's title in the episode label, this change improves clarity and ensures better context in list views.

See example below that depicts the before and after:

<img width="1800" alt="Screenshot 2024-12-17 at 8 49 00 PM" src="https://github.com/user-attachments/assets/328b0ba9-61ac-4f6d-ade2-6f9fafe92946" />

<img width="1800" alt="Screenshot 2024-12-17 at 8 49 24 PM" src="https://github.com/user-attachments/assets/b989824a-01f0-4eea-b039-0bc20d75aa3d" />
