### PR TITLE
🐛 Resolves missing 'dbid_sorted' attribute error in sync lists

### DIFF
--- a/resources/tmdbhelper/lib/items/directories/trakt/lists_sync.py
+++ b/resources/tmdbhelper/lib/items/directories/trakt/lists_sync.py
@@ -48,6 +48,7 @@ class ListStandardSync(ListDefault):
         list_properties.filters = None  # Filters for pre-pagination
         list_properties.item_keys = None  # Extra keys for filters
         list_properties.plugin_name = '{plural} {localized}'
+        list_properties.dbid_sorted = True
         list_properties.localize = None
         list_properties.params_def = None
         return list_properties


### PR DESCRIPTION
Watchlist, Collection, Favourites, etc. weren't working and giving the missing attribute error when trying to access them inside TMDbH.

This resolves the issue but I'm not sure if it's the correct way. Should it be 'None' or 'False' instead of 'True'?