### PR TITLE
Fix TMBD lookups in PVR submenus

### DIFF
--- a/resources/tmdbhelper/lib/monitor/itemdetails.py
+++ b/resources/tmdbhelper/lib/monitor/itemdetails.py
@@ -113,9 +113,10 @@ class MonitorItemDetails(ImageManipulations):
         return get_condvisibility((
             'Window.IsVisible(DialogPVRInfo.xml) | '
             'Window.IsVisible(MyPVRChannels.xml) | '
+            'Window.IsVisible(MyPVRGuide.xml) | '
             'Window.IsVisible(MyPVRRecordings.xml) | '
             'Window.IsVisible(MyPVRSearch.xml) | '
-            'Window.IsVisible(MyPVRGuide.xml)'
+            'Window.IsVisible(MyPVRTimers.xml)'
         ))
 
     @cached_property

--- a/resources/tmdbhelper/lib/monitor/poller.py
+++ b/resources/tmdbhelper/lib/monitor/poller.py
@@ -35,7 +35,10 @@ WINDOW_XML_MEDIA = (
     'MyPlaylist.xml',
     'MyGames.xml',
     'MyPVRChannels.xml',
-    'MyPVRGuide.xml'
+    'MyPVRGuide.xml',
+    'MyPVRRecordings.xml',
+    'MyPVRSearch.xml',
+    'MyPVRTimers.xml'
 )
 
 WINDOW_XML_INFODIALOG = (


### PR DESCRIPTION
TMDB lookups were not working in three menus (recordings, search and timers).

Tested in Arctic Fuse 2 & 3.