### PR TITLE
Add widgets_library_only setting to filter widgets by local library

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2685,6 +2685,16 @@ msgctxt "#32536"
 msgid "Unspecified"
 msgstr ""
 
+#: /resources/settings.xml
+msgctxt "#32537"
+msgid "Only show library items in widgets"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32538"
+msgid "When enabled, widgets will only display items that exist in your local Kodi library."
+msgstr ""
+
 msgctxt "#30030"
 msgid "Hindi (India)"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2695,6 +2695,22 @@ msgctxt "#32538"
 msgid "When enabled, widgets will only display items that exist in your local Kodi library."
 msgstr ""
 
+msgctxt "#32539"
+msgid "Popular (Movies & TV)"
+msgstr ""
+
+msgctxt "#32540"
+msgid "Trending Today (Movies & TV)"
+msgstr ""
+
+msgctxt "#32541"
+msgid "Trending This Week (Movies & TV)"
+msgstr ""
+
+msgctxt "#32542"
+msgid "Movies & TV"
+msgstr ""
+
 msgctxt "#30030"
 msgid "Hindi (India)"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -194,6 +194,11 @@
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
+                <setting id="widgets_library_only" type="boolean" label="32537" help="32538">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
             </group>
             <group id="2" label="32368">
                 <setting id="calendar_flatten" type="boolean" label="32404" help="">

--- a/resources/tmdbhelper/lib/api/kodi/rpc.py
+++ b/resources/tmdbhelper/lib/api/kodi/rpc.py
@@ -182,6 +182,12 @@ class KodiLibrary(object):
 
         return database
 
+    def get_tmdb_ids(self):
+        """Return set of all TMDb IDs in the library for fast lookup."""
+        if not self.database:
+            return set()
+        return {str(item['tmdb_id']) for item in self.database if item.get('tmdb_id')}
+
     def _get_info(
         self, info, dbid=None, imdb_id=None, originaltitle=None, title=None, year=None,
         season=None, episode=None, fuzzy_match=False, tmdb_id=None, tvdb_id=None

--- a/resources/tmdbhelper/lib/items/container.py
+++ b/resources/tmdbhelper/lib/items/container.py
@@ -56,6 +56,18 @@ class ContainerDirectoryCommon(CommonContainerAPIs):
         return boolean(self.params.get('widget', False))
 
     @cached_property
+    def is_library_only(self):
+        """Check if library-only filtering is enabled."""
+        # URL parameter takes precedence
+        param_value = self.params.get('library_only')
+        if param_value is not None:
+            return boolean(param_value)
+        # Only apply global setting to widgets
+        if self.is_widget:
+            return get_setting('widgets_library_only')
+        return False
+
+    @cached_property
     def is_cacheonly(self):
         return boolean(self.params.get('cacheonly', self.default_cacheonly))
 
@@ -97,6 +109,8 @@ class ContainerDirectoryCommon(CommonContainerAPIs):
             return False
         if self.is_widget and not get_setting('widgets_nextpage'):
             return False
+        if self.is_library_only:
+            return False  # Disable pagination for library-only widgets
         return True
 
     @cached_property

--- a/resources/tmdbhelper/lib/items/directories/base/basedir_main.py
+++ b/resources/tmdbhelper/lib/items/directories/base/basedir_main.py
@@ -24,6 +24,13 @@ class BaseDirItemMainPerson(BaseDirItemMainMovie):
     art_icon = 'resources/icons/themoviedb/cast.png'
 
 
+class BaseDirItemMainAll(BaseDirItemMainMovie):
+    priority = 125
+    label_localized = 32542
+    params = {'info': 'dir_all'}
+    art_icon = 'resources/icons/themoviedb/default.png'
+
+
 class BaseDirItemMainMultiSearch(BaseDirItemMainMovie):
     priority = 130
     label_localized = 137

--- a/resources/tmdbhelper/lib/items/directories/base/basedir_tmdb.py
+++ b/resources/tmdbhelper/lib/items/directories/base/basedir_tmdb.py
@@ -57,6 +57,33 @@ class BaseDirItemTMDbTrendingWeek(BaseDirItem):
     group = 32204
 
 
+class BaseDirItemTMDbPopularAll(BaseDirItem):
+    priority = 111
+    label_localized = 32539
+    params = {'info': 'popular', 'tmdb_type': 'all'}
+    art_icon = 'resources/icons/themoviedb/popular.png'
+    types = ('all',)
+    group = 32175
+
+
+class BaseDirItemTMDbTrendingDayAll(BaseDirItem):
+    priority = 141
+    label_localized = 32540
+    params = {'info': 'trending_day', 'tmdb_type': 'all'}
+    art_icon = 'resources/icons/themoviedb/upcoming.png'
+    types = ('all',)
+    group = 32204
+
+
+class BaseDirItemTMDbTrendingWeekAll(BaseDirItem):
+    priority = 151
+    label_localized = 32541
+    params = {'info': 'trending_week', 'tmdb_type': 'all'}
+    art_icon = 'resources/icons/themoviedb/upcoming.png'
+    types = ('all',)
+    group = 32204
+
+
 class BaseDirItemTMDbNowPlaying(BaseDirItem):
     priority = 160
     label_localized = 32180

--- a/resources/tmdbhelper/lib/items/directories/base/lists_base.py
+++ b/resources/tmdbhelper/lib/items/directories/base/lists_base.py
@@ -158,6 +158,7 @@ class ListBaseDir(ContainerDirectory):
             'dir_movie': lambda: BaseDirList(tmdb=True, trakt=True).build_basedir('movie', group=group),
             'dir_tv': lambda: BaseDirList(tmdb=True, trakt=True).build_basedir('tv', group=group),
             'dir_person': lambda: BaseDirList(tmdb=True, trakt=True).build_basedir('person', group=group),
+            'dir_all': lambda: BaseDirList(tmdb=True).build_basedir('all', group=group),
             'dir_tmdb': lambda: BaseDirList(tmdb=True).build_basedir(group=group, info='dir_tmdb'),
             'dir_trakt': lambda: BaseDirList(trakt=True).build_basedir(group=group, info='dir_trakt'),
             'dir_mdblist': lambda: BaseDirList(mdblist=True).build_basedir(group=group),

--- a/resources/tmdbhelper/lib/items/directories/lists_default.py
+++ b/resources/tmdbhelper/lib/items/directories/lists_default.py
@@ -260,9 +260,16 @@ class ListDefault(ContainerDefaultCacheDirectory):
         the user's saved setting.
         """
         tmdb_type = self.params.get('tmdb_type')
-        if tmdb_type not in ('movie', 'tv'):
+        if tmdb_type not in ('movie', 'tv', 'all'):
             return None
         from tmdbhelper.lib.api.kodi.rpc import get_kodi_library
+        if tmdb_type == 'all':
+            # Fetch both movie and TV library IDs
+            movie_lib = get_kodi_library('movie')
+            tv_lib = get_kodi_library('tv')
+            movie_ids = movie_lib.get_tmdb_ids() if movie_lib else set()
+            tv_ids = tv_lib.get_tmdb_ids() if tv_lib else set()
+            return movie_ids | tv_ids  # Union of both sets
         kodi_lib = get_kodi_library(tmdb_type)
         if not kodi_lib:
             return None

--- a/resources/tmdbhelper/lib/items/directories/lists_default.py
+++ b/resources/tmdbhelper/lib/items/directories/lists_default.py
@@ -84,6 +84,11 @@ class ListProperties:
     pagination = False
     is_cacheonly = True
 
+    # Library-only filtering properties
+    is_library_only = False
+    library_tmdb_ids = None
+    library_target_count = 20
+
     @cached_property
     def query_database(self):
         from tmdbhelper.lib.query.database.database import FindQueriesDatabase
@@ -242,7 +247,26 @@ class ListDefault(ContainerDefaultCacheDirectory):
         list_properties.trakt_api = self.trakt_api
         list_properties.is_cacheonly = self.is_cacheonly
         list_properties.class_name = f'{self.__class__.__name__}'
+        # Library-only filtering configuration
+        list_properties.is_library_only = getattr(self, 'is_library_only', False)
+        list_properties.library_tmdb_ids = self._get_library_tmdb_ids() if list_properties.is_library_only else None
         return list_properties
+
+    def _get_library_tmdb_ids(self):
+        """Pre-fetch library TMDb IDs for early filtering.
+
+        Note: Temporarily enables Kodi DB lookup for this request even if
+        the user has 'use_kodi_local_db' set to 0. This does NOT modify
+        the user's saved setting.
+        """
+        tmdb_type = self.params.get('tmdb_type')
+        if tmdb_type not in ('movie', 'tv'):
+            return None
+        from tmdbhelper.lib.api.kodi.rpc import get_kodi_library
+        kodi_lib = get_kodi_library(tmdb_type)
+        if not kodi_lib:
+            return None
+        return kodi_lib.get_tmdb_ids()
 
     @cached_property
     def sort_by_dbid(self):

--- a/resources/tmdbhelper/lib/items/directories/tmdb/lists_standard.py
+++ b/resources/tmdbhelper/lib/items/directories/tmdb/lists_standard.py
@@ -1,6 +1,9 @@
 from tmdbhelper.lib.items.directories.lists_default import UncachedItemsPage, ListDefault, ListProperties
 from tmdbhelper.lib.addon.plugin import get_setting
 
+# Constants for library-only mode
+LIBRARY_ONLY_MAX_PAGES = 10
+
 
 class ListStandardProperties(ListProperties):
 
@@ -16,13 +19,50 @@ class ListStandardProperties(ListProperties):
         return self.tmdb_api.get_response_json(self.url, page=page)
 
     def get_uncached_items(self):
+        # Standard behavior when library_only is not active
+        if not self.is_library_only or not self.library_tmdb_ids:
+            return {
+                'items': [
+                    i for xpage in range(self.page, self.next_page)
+                    for i in self.class_pages(self, xpage).items
+                ],
+                'pages': self.total_pages,
+                'count': self.total_items,
+            }
+
+        # Library-only mode: accumulate pages until we have enough matches
+        matching_items = []
+        current_page = self.page
+        pages_fetched = 0
+
+        while pages_fetched < LIBRARY_ONLY_MAX_PAGES:
+            page_data = self.class_pages(self, current_page)
+
+            # No more pages available
+            if not page_data.items:
+                break
+            if self.total_pages and current_page > self.total_pages:
+                break
+
+            # Filter items by library TMDb IDs
+            for item in page_data.items:
+                tmdb_id = str(item.get('unique_ids', {}).get('tmdb', ''))
+                if tmdb_id and tmdb_id in self.library_tmdb_ids:
+                    matching_items.append(item)
+                    if len(matching_items) >= self.library_target_count:
+                        break
+
+            pages_fetched += 1
+            current_page += 1
+
+            # Stop if we have enough items
+            if len(matching_items) >= self.library_target_count:
+                break
+
         return {
-            'items': [
-                i for xpage in range(self.page, self.next_page)
-                for i in self.class_pages(self, xpage).items
-            ],
-            'pages': self.total_pages,
-            'count': self.total_items,
+            'items': matching_items,
+            'pages': 0,  # No pagination for library-only
+            'count': len(matching_items),
         }
 
     def get_mapped_item(self, item, add_infoproperties=None):

--- a/resources/tmdbhelper/lib/items/directories/trakt/lists_standard.py
+++ b/resources/tmdbhelper/lib/items/directories/trakt/lists_standard.py
@@ -5,6 +5,9 @@ from tmdbhelper.lib.addon.plugin import get_setting
 from jurialmunkey.ftools import cached_property
 from jurialmunkey.parser import try_int
 
+# Constants for library-only mode
+LIBRARY_ONLY_MAX_PAGES = 10
+
 
 class UncachedTraktItemsPage(UncachedItemsPage):
     @cached_property
@@ -67,10 +70,47 @@ class ListTraktStandardProperties(ListStandardProperties):
         return self.request_url.format(trakt_type=self.trakt_type)
 
     def get_uncached_items(self):
+        # Standard behavior when library_only is not active
+        if not self.is_library_only or not self.library_tmdb_ids:
+            return {
+                'items': self.class_pages(self, self.page).items,
+                'pages': self.total_pages,
+                'count': self.total_items,
+            }
+
+        # Library-only mode: accumulate pages until we have enough matches
+        matching_items = []
+        current_page = self.page
+        pages_fetched = 0
+
+        while pages_fetched < LIBRARY_ONLY_MAX_PAGES:
+            page_data = self.class_pages(self, current_page)
+
+            # No more pages available
+            if not page_data.items:
+                break
+            if self.total_pages and current_page > self.total_pages:
+                break
+
+            # Filter items by library TMDb IDs
+            for item in page_data.items:
+                tmdb_id = str(item.get('unique_ids', {}).get('tmdb', ''))
+                if tmdb_id and tmdb_id in self.library_tmdb_ids:
+                    matching_items.append(item)
+                    if len(matching_items) >= self.library_target_count:
+                        break
+
+            pages_fetched += 1
+            current_page += 1
+
+            # Stop if we have enough items
+            if len(matching_items) >= self.library_target_count:
+                break
+
         return {
-            'items': self.class_pages(self, self.page).items,
-            'pages': self.total_pages,
-            'count': self.total_items,
+            'items': matching_items,
+            'pages': 0,  # No pagination for library-only
+            'count': len(matching_items),
         }
 
     def get_api_response(self, page=1):


### PR DESCRIPTION
## Summary

Adds a new setting that filters widget results to only show items that exist in the user's local Kodi library.

**Problem:** Widgets like "Now Playing" or "Trending" show content that users may not have locally. Using existing URL filters (`exclude_key=dbid&exclude_value=is_empty`) results in sparse widgets (2-3 items instead of 20) because filtering happens after fetching a fixed page size.

**Solution:** Pre-fetch library TMDb IDs and filter early during API fetch, accumulating pages until enough matching items are found.

### Features
- New setting in **Widgets** section: "Only show library items in widgets"
- URL parameter `library_only=true/false` for per-widget override
- Supports both TMDb and Trakt list types
- Fetches up to 10 API pages to find matching library items (up to 20 matches)
- Pagination automatically disabled when library_only is active
- **NEW:** "Movies & TV" mixed content support with `tmdb_type=all`

### Mixed Content (Movies & TV)
- New main menu entry: "Movies & TV" 
- New widget presets:
  - Popular (Movies & TV)
  - Trending Today (Movies & TV)
  - Trending This Week (Movies & TV)
- Library filtering works with mixed content by combining movie and TV library IDs

### Files Changed
- `resources/settings.xml` - New boolean setting
- `resources/language/resource.language.en_gb/strings.po` - Localization strings
- `resources/tmdbhelper/lib/api/kodi/rpc.py` - `get_tmdb_ids()` helper method
- `resources/tmdbhelper/lib/items/container.py` - `is_library_only` property
- `resources/tmdbhelper/lib/items/directories/lists_default.py` - Library config propagation + `tmdb_type=all` support
- `resources/tmdbhelper/lib/items/directories/tmdb/lists_standard.py` - TMDb filtering logic
- `resources/tmdbhelper/lib/items/directories/trakt/lists_standard.py` - Trakt filtering logic
- `resources/tmdbhelper/lib/items/directories/base/basedir_tmdb.py` - Mixed content widget presets
- `resources/tmdbhelper/lib/items/directories/base/basedir_main.py` - "Movies & TV" main menu entry
- `resources/tmdbhelper/lib/items/directories/base/lists_base.py` - `dir_all` route

## Test plan
- [x] Setting appears in addon settings under Widgets section
- [x] Setting toggle works (enable/disable)
- [x] Movies widget only shows movies in library when enabled
- [x] TV shows widget only shows shows in library when enabled
- [x] No "next page" item when library_only is active
- [x] URL parameter `library_only=true` works independently of setting
- [x] URL parameter `library_only=false` overrides enabled setting
- [x] "Movies & TV" mixed content widgets work with library_only filtering

## Usage Examples

**With global setting enabled:**
```
plugin://plugin.video.themoviedb.helper/?info=popular&tmdb_type=movie&widget=true
```
Shows only popular movies that are in user's Kodi library

**Mixed content (Movies & TV):**
```
plugin://plugin.video.themoviedb.helper/?info=trending_week&tmdb_type=all&widget=true
```
Shows trending movies AND TV shows that are in user's Kodi library