### PR TITLE
🐛 Add missing `rottentomatoes_image` to database

### DIFF
--- a/resources/tmdbhelper/lib/items/database/database.py
+++ b/resources/tmdbhelper/lib/items/database/database.py
@@ -45,7 +45,7 @@ class ItemDetailsDatabase(Database):
         super().__init__(filename=self.cache_filename)
 
     # DB version must be max of table_version
-    database_version = 39
+    database_version = 40
 
     database_changes = {
         21: (),
@@ -100,6 +100,9 @@ class ItemDetailsDatabase(Database):
             'DROP TABLE IF EXISTS user_art',
             'DROP TABLE IF EXISTS unique_id',
             'DROP TABLE IF EXISTS translation',
+        ),
+        40: (
+            'DROP TABLE IF EXISTS ratings',
         )
     }
 

--- a/resources/tmdbhelper/lib/items/database/tabledef.py
+++ b/resources/tmdbhelper/lib/items/database/tabledef.py
@@ -317,6 +317,9 @@ RATINGS_COLUMNS = {
     'rottentomatoes_consensus': {
         'data': 'TEXT',
     },
+    'rottentomatoes_image': {
+        'data': 'TEXT',
+    },
     'metacritic_rating': {
         'data': 'INTEGER',
     },


### PR DESCRIPTION
Hey Jurial,

Hope you're doing well!

I noticed that the value was missing, so Arctic skins weren't able to display the "certified" icon in the ratings line. Also updated the database version to clear the cached details.

Related AF3 PR: https://github.com/jurialmunkey/skin.arctic.fuse.3/pull/236

Note: I have also noticed that the `rottentomatoes_consensus` value has been `N/A` for every title.
This is very old news and you probably already know this, but OMDb removed a lot of RT data to comply with RT/Fandango demands: https://www.patreon.com/posts/rating-changes-8417367

Glad you're using XML instead of JSON to retrieve details as the latter returns `N/A` for ALL RT data, whereas you're still able to get almost everything with XML (no idea why haha) except the consensus value.

Here's an example:

### JSON

```json
{
  "Title": "The Godfather Part II",
  "Year": "1974",
  "Rated": "R",
  "Released": "18 Dec 1974",
  "Runtime": "202 min",
  "Genre": "Crime, Drama",
  "Director": "Francis Ford Coppola",
  "Writer": "Francis Ford Coppola, Mario Puzo",
  "Actors": "Al Pacino, Robert De Niro, Robert Duvall",
  "Plot": "The continuing saga of the Corleone crime family tells the story of a young Vito Corleone growing up in Sicily and in 1910s New York; and follows Michael Corleone in the 1950s as he attempts to expand the family business into Las Vegas, Hollywood and Cuba.",
  "Language": "English, Italian, Spanish, Latin, Sicilian",
  "Country": "United States",
  "Awards": "Won 6 Oscars. 17 wins & 21 nominations total",
  "Poster": "https://m.media-amazon.com/images/M/MV5BMDIxMzBlZDktZjMxNy00ZGI4LTgxNDEtYWRlNzRjMjJmOGQ1XkEyXkFqcGc@._V1_SX300.jpg",
  "Ratings": [
    {
      "Source": "Internet Movie Database",
      "Value": "9.0/10"
    },
    {
      "Source": "Rotten Tomatoes",
      "Value": "96%"
    },
    {
      "Source": "Metacritic",
      "Value": "90/100"
    }
  ],
  "Metascore": "90",
  "imdbRating": "9.0",
  "imdbVotes": "1,478,804",
  "imdbID": "tt0071562",
  "Type": "movie",
  "tomatoMeter": "N/A",
  "tomatoImage": "N/A",
  "tomatoRating": "N/A",
  "tomatoReviews": "N/A",
  "tomatoFresh": "N/A",
  "tomatoRotten": "N/A",
  "tomatoConsensus": "N/A",
  "tomatoUserMeter": "N/A",
  "tomatoUserRating": "N/A",
  "tomatoUserReviews": "N/A",
  "tomatoURL": "https://www.rottentomatoes.com/m/godfather_part_ii/",
  "DVD": "N/A",
  "BoxOffice": "$47,834,595",
  "Production": "N/A",
  "Website": "N/A",
  "Response": "True"
}
```

### XML
```xml
<root response="True">
<movie title="The Godfather Part II" year="1974" rated="R" released="18 Dec 1974" runtime="202 min" genre="Crime, Drama" director="Francis Ford Coppola" writer="Francis Ford Coppola, Mario Puzo" actors="Al Pacino, Robert De Niro, Robert Duvall" plot="The continuing saga of the Corleone crime family tells the story of a young Vito Corleone growing up in Sicily and in 1910s New York; and follows Michael Corleone in the 1950s as he attempts to expand the family business into Las Vegas, Hollywood and Cuba." language="English, Italian, Spanish, Latin, Sicilian" country="United States" awards="Won 6 Oscars. 17 wins & 21 nominations total" poster="https://m.media-amazon.com/images/M/MV5BMDIxMzBlZDktZjMxNy00ZGI4LTgxNDEtYWRlNzRjMjJmOGQ1XkEyXkFqcGc@._V1_SX300.jpg" metascore="90" imdbRating="9.0" imdbVotes="1,478,804" imdbID="tt0071562" type="movie" tomatoMeter="96" tomatoImage="certified" tomatoRating="9.8" tomatoReviews="129" tomatoFresh="124" tomatoRotten="5" tomatoConsensus="N/A" tomatoUserMeter="97" tomatoUserRating="4.7" tomatoUserReviews="18711" tomatoeURL="https://www.rottentomatoes.com/m/godfather_part_ii/" DVD="N/A" BoxOffice="N/A" Production="N/A" Website="N/A"/>
</root>
```

I can squash another commit to remove `rottentomatoes_consensus` if you think it's no longer needed.

Thanks!