### PR TITLE
Skip database VACUUM while a player is active

### DIFF
--- a/resources/tmdbhelper/lib/script/method/maintenance.py
+++ b/resources/tmdbhelper/lib/script/method/maintenance.py
@@ -61,6 +61,13 @@ class DatabaseMaintenance:
     def vacuum(self, force=False):
         if not force and not self.is_next_vacuum:
             return
+        # p3i: skip vacuum while Kodi is playing — VACUUM holds the SQLite
+        # file lock and fsyncs a full DB-sized temp copy, which can stall
+        # the video pipeline thread long enough to drop frames on UHD.
+        if not force:
+            import xbmc
+            if xbmc.Player().isPlaying():
+                return
         self.set_next_vacuum()
         from tmdbhelper.lib.addon.logger import TimerFunc
         from tmdbhelper.lib.items.database.database import ItemDetailsDatabase


### PR DESCRIPTION
## Summary

Defer the periodic database `VACUUM` triggered from `CronJobMonitor` while Kodi is playing media. `force=True` callers (manual maintenance triggers) are unaffected; the next cron tick picks up the deferred vacuum once playback ends.

## Why

On constrained CoreELEC boxes I've been seeing user reports of microstutter during high-bitrate UHD playback at roughly 10-minute intervals. One report came in with a full debug log, and the stall lines up exactly with a `Vacuuming databases: 7.401 sec` event:

```
14:30:54.939  T:5284  AddData  lv:13.5%
14:30:54.966  T:3941  ReleaseFrame idx:343479, drop:0
14:30:55.347  T:5284  GetPicture idx:343483 elf:412ms     <- 381ms stall
14:30:55.347  T:5284  OutputPicture ttd:-52ms              <- frame late
14:30:55.350  T:3941  ReleaseFrame idx:343480, drop:1
                       (six frames dropped in cascade)
...
14:30:49.254  T:4070  [plugin.video.themoviedb.helper]    <- vacuum start
14:30:56.655  T:4070  Vacuuming databases: 7.401 sec      <- vacuum end
```

`VACUUM` holds the SQLite file lock and fsyncs a full DB-sized temp copy. On these boxes that's enough to delay the video pipeline thread past frame deadlines.

## Test plan

- [x] Vacuum still runs as before when nothing is playing.
- [x] During playback, `vacuum()` returns immediately; the next cron tick re-evaluates.
- [x] Manual / `force=True` triggers are unaffected.