### PR TITLE
Fix In Progress / Next Episode widgets broken by Trakt API change (request extended=progress)

### DIFF
--- a/resources/tmdbhelper/lib/api/trakt/sync/datatype.py
+++ b/resources/tmdbhelper/lib/api/trakt/sync/datatype.py
@@ -197,7 +197,11 @@ class SyncHiddenDropped(SyncHiddenProgressWatched):
 class SyncWatched(DataTypeEpisodes):
     keys = ('plays', 'last_watched_at', 'last_updated_at', 'aired_episodes', 'watched_episodes', 'reset_at', )
     last_activities_key = 'watched_at'
-    sync_kwgs = {'extended': 'full'}
+    # Trakt stopped returning the 'seasons' array from /sync/watched/shows unless
+    # 'progress' is requested (see trakt/trakt-api#835). Without it watched_episodes
+    # is never counted (stays None) and is_inprogress_show raises on 'aired <= None',
+    # breaking the In Progress and Next Episode widgets.
+    sync_kwgs = {'extended': 'full,progress'}
     method = 'watched'
 
 


### PR DESCRIPTION
### Problem

As of ~2026-07-01 the **In Progress** and **Next Episode** Trakt widgets error out for everyone (see #1833, and related #1830 / #1831). The log shows:

```
File ".../trakt/sync/datasync.py", line 318, in is_inprogress_show
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```

### Root cause

Trakt changed `/sync/watched/shows` to **no longer include the `seasons` array unless `extended=progress` is requested** — a Trakt-side change tracked at **trakt/trakt-api#835**. Verified directly against the API with a real account:

| Request | Shows with `seasons` |
|---|---|
| `GET /sync/watched/shows` | **0 / 41** |
| `GET /sync/watched/shows?extended=full` | **0 / 41** |
| `GET /sync/watched/shows?extended=full,progress` | **41 / 41** |

`SyncWatched` requests `extended=full` and counts `watched_episodes` from `item['seasons']` in `sync_seasons()`. With no `seasons`, that method returns early and `watched_episodes` stays `None`, which then crashes `is_inprogress_show()` on `aired_episodes <= watched_episodes`.

### Fix

Add `progress` to the watched sync's extended params (`full,progress`). Only `SyncWatched` (method `watched`) is touched; the returned `seasons` data restores correct `watched_episodes` counting.

### Verified

Applied on Kodi 21.3 / Arctic Fuse 3 with a live Trakt account: In Progress again lists only shows with unwatched aired episodes (fully-watched shows are correctly hidden), Next Episode works, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
