### PR TITLE
Fix SQLite connection lifecycle across threads

### DIFF
--- a/resources/tmdbhelper/lib/api/contains.py
+++ b/resources/tmdbhelper/lib/api/contains.py
@@ -1,4 +1,4 @@
-from jurialmunkey.ftools import cached_property
+from jurialmunkey.ftools import cached_property, threaded_cached_property
 
 
 class CommonContainerAPIs():
@@ -50,7 +50,7 @@ class CommonContainerAPIs():
             return
         return OMDb()
 
-    @cached_property
+    @threaded_cached_property
     def query_database(self):
         from tmdbhelper.lib.query.database.database import FindQueriesDatabase
         return FindQueriesDatabase()

--- a/resources/tmdbhelper/lib/api/gemini/api.py
+++ b/resources/tmdbhelper/lib/api/gemini/api.py
@@ -2,7 +2,7 @@ from json import loads
 from tmdbhelper.lib.addon.plugin import get_setting, get_localized
 from tmdbhelper.lib.addon.logger import kodi_log
 from tmdbhelper.lib.api.request import RequestAPI
-from jurialmunkey.ftools import cached_property
+from jurialmunkey.ftools import cached_property, threaded_cached_property
 import re
 
 
@@ -166,7 +166,7 @@ class Gemini(RequestAPI):
         string = string.replace('\n', '[CR]')
         return string
 
-    @cached_property
+    @threaded_cached_property
     def database(self):
         from tmdbhelper.lib.query.database.database import FindQueriesDatabase
         return FindQueriesDatabase()

--- a/resources/tmdbhelper/lib/api/trakt/sync/datasync.py
+++ b/resources/tmdbhelper/lib/api/trakt/sync/datasync.py
@@ -9,10 +9,9 @@ from tmdbhelper.lib.files.dbdata import DatabaseStatements
 
 class SyncItemDetailsDatabase(ItemDetailsDatabase):
     def set_activity(self, item_type, method, value, expiry):
-        cursor = self.execute_sql(
+        self.execute_sql_and_close(
             DatabaseStatements.insert_or_replace('lactivities', keys=('id', 'data', 'expiry')),
             (f'{item_type}.{method}', value, expiry))
-        cursor.close() if cursor else None
 
     def get_activity(self, item_type, method, expiry=0):
         cursor = self.execute_sql(
@@ -20,8 +19,10 @@ class SyncItemDetailsDatabase(ItemDetailsDatabase):
             (f'{item_type}.{method}', expiry))
         if not cursor:
             return
-        result = cursor.fetchone()
-        cursor.close()
+        try:
+            result = cursor.fetchone()
+        finally:
+            self.close_cursor(cursor, close_connection=True)
         if not result:
             return
         return result[0]

--- a/resources/tmdbhelper/lib/files/dbdata.py
+++ b/resources/tmdbhelper/lib/files/dbdata.py
@@ -3,6 +3,7 @@
 from tmdbhelper.lib.addon.logger import kodi_log, TimerFunc
 from tmdbhelper.lib.addon.plugin import get_setting, get_version
 from tmdbhelper.lib.files.futils import FileUtils
+import re
 import sqlite3
 
 
@@ -68,43 +69,58 @@ class DatabaseCore:
 
     def set_pragmas(self, connection):
         cursor = connection.cursor()
-        cursor.execute("PRAGMA synchronous=NORMAL")
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.execute("PRAGMA mmap_size=268435456")
+        try:
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.execute("PRAGMA mmap_size=268435456")
+        finally:
+            cursor.close()
         return connection
 
     def init_database(self):
         # import xbmcvfs
         from jurialmunkey.locker import MutexPropLock
         with MutexPropLock(f'{self._db_file}.lockfile', kodi_log=self.kodi_log):
+            if self.database_initialized:
+                return True
             # if xbmcvfs.exists(self._db_file):
             #     self.set_database_init()
             #     return
-            database = self.create_database()
+            if not self.create_database():
+                return False
             self.set_database_init()
-        return database
+        return True
 
     def create_database(self):
+        connection = None
         try:
             with TimerFunc(f'CACHE: Initialisation {self._db_file} took:'):
                 self.kodi_log(f'CACHE: Initialising...\n{self._db_file}\n{self._sc_name}', 1)
                 connection = sqlite3.connect(self._db_file, timeout=self._db_timeout)
-                connection = self.set_pragmas(connection)
-                connection = self.create_database_execute(connection)
-            return connection
+                with connection:
+                    self.set_pragmas(connection)
+                    self.create_database_execute(connection)
+            return True
         except Exception as error:
             self.kodi_log(f'CACHE: Exception while initializing _database: {error}\n{self._sc_name}', 1)
+            return False
+        finally:
+            if connection:
+                connection.close()
 
     def get_database(self, read_only=False, log_level=1):
         timeout = self._db_read_timeout if read_only else self._db_timeout
+        connection = None
         try:
             connection = sqlite3.connect(self._db_file, timeout=timeout)
+            connection.row_factory = sqlite3.Row
+            return self.set_pragmas(connection)
         except Exception as error:
+            if connection:
+                connection.close()
             self.kodi_log(f'CACHE: ERROR while retrieving _database: {error}\n{self._sc_name}', log_level)
             return
-        connection.row_factory = sqlite3.Row
-        return self.set_pragmas(connection)
 
     def database_execute(self, connection, query, data=None):
         try:
@@ -115,23 +131,81 @@ class DatabaseCore:
             return connection.execute(query, data)
         except sqlite3.OperationalError as operational_exception:
             self.kodi_log(f'CACHE: database OPERATIONAL ERROR! -- {operational_exception}\n{self._sc_name}\n--query--\n{query}\n--data--\n{data}', 2)
+            raise
         except Exception as other_exception:
             self.kodi_log(f'CACHE: database OTHER ERROR! -- {other_exception}\n{self._sc_name}\n--query--\n{query}\n--data--\n{data}', 2)
+            raise
 
     def execute_sql(self, query, data=None, read_only=False, connection=None):
+        if connection:
+            return self.database_execute(connection, query, data=data)
+
+        database_connection = None
         try:
-            if connection:
-                return self.database_execute(connection, query, data=data)
-            with self.get_database(read_only=read_only) as connection:
-                return self.database_execute(connection, query, data=data)
+            database_connection = self.get_database(read_only=read_only)
+            if not database_connection:
+                return
+            with database_connection:
+                cursor = self.database_execute(database_connection, query, data=data)
+            if not cursor:
+                database_connection.close()
+            return cursor
         except Exception as database_exception:
+            if database_connection:
+                database_connection.close()
             self.kodi_log(f'CACHE: database GET DATABASE ERROR! -- {database_exception}\n{self._sc_name} -- read_only: {read_only}', 2)
+
+    @staticmethod
+    def close_cursor(cursor, close_connection=False):
+        if not cursor:
+            return
+        connection = cursor.connection if close_connection else None
+        try:
+            cursor.close()
+        finally:
+            if connection:
+                connection.close()
+
+    def execute_sql_and_close(self, query, data=None, read_only=False):
+        cursor = self.execute_sql(query, data=data, read_only=read_only)
+        self.close_cursor(cursor, close_connection=True)
 
     @property
     def database_tables(self):
         return {}
 
     def create_database_execute(self, connection):
+
+        def execute(cursor, query):
+            try:
+                return cursor.execute(query)
+            except Exception as error:
+                self.kodi_log(
+                    f'CACHE: Exception while initializing _database: {error}\n'
+                    f'{self._sc_name} - {query}',
+                    1)
+                raise
+
+        def migration_already_applied(cursor, query):
+            match = re.match(
+                r'^\s*ALTER\s+TABLE\s+([A-Za-z_]\w*)\s+ADD(?:\s+COLUMN)?\s+([A-Za-z_]\w*)\b',
+                query,
+                flags=re.IGNORECASE)
+            if not match:
+                return False
+            table, column = match.groups()
+            table_columns = execute(cursor, f'PRAGMA table_info("{table}")').fetchall()
+            if not table_columns:
+                current_columns = next((
+                    columns
+                    for current_table, columns in self.database_tables.items()
+                    if current_table.casefold() == table.casefold()
+                ), None)
+                return bool(current_columns) and any(
+                    current_column.casefold() == column.casefold()
+                    for current_column in current_columns
+                )
+            return any(row[1].casefold() == column.casefold() for row in table_columns)
 
         def create_column_data(columns):
             return [
@@ -156,52 +230,44 @@ class DatabaseCore:
             return ['UNIQUE ({})'.format(', '.join(keys))]
 
         cursor = connection.cursor()
-        this_database_version = cursor.execute("PRAGMA user_version").fetchone()[0]
+        try:
+            execute(cursor, "BEGIN")
+            this_database_version = execute(cursor, "PRAGMA user_version").fetchone()[0]
 
-        # OLD DATABASE SCHEME: APPLY MODIFICATIONS
-        if this_database_version and this_database_version < self.database_version:
-            for version, changes in self.database_changes.items():
-                if version <= this_database_version:
-                    continue
-                for query in changes:
-                    try:
-                        cursor.execute(query)
-                    except Exception as error:
-                        self.kodi_log(f'CACHE: Exception while initializing _database: {error}\n{self._sc_name} - {query}', 1)
+            # OLD DATABASE SCHEME: APPLY MODIFICATIONS
+            if this_database_version and this_database_version < self.database_version:
+                for version, changes in self.database_changes.items():
+                    if version <= this_database_version:
+                        continue
+                    for query in changes:
+                        if migration_already_applied(cursor, query):
+                            continue
+                        execute(cursor, query)
 
-        # CREATE TABLES IF NOT EXISTS
-        for table, columns in self.database_tables.items():
-            query = []
-            query += create_column_data(columns)
-            query += create_column_fkey(columns)
-            query += create_column_uids(columns)
-            query = 'CREATE TABLE IF NOT EXISTS {table}({query})'.format(table=table, query=', '.join(query))
-            try:
-                cursor.execute(query)
-            except Exception as error:
-                self.kodi_log(f'CACHE: Exception while initializing _database: {error}\n{self._sc_name} - {query}', 1)
+            # CREATE TABLES IF NOT EXISTS
+            for table, columns in self.database_tables.items():
+                query = []
+                query += create_column_data(columns)
+                query += create_column_fkey(columns)
+                query += create_column_uids(columns)
+                query = 'CREATE TABLE IF NOT EXISTS {table}({query})'.format(table=table, query=', '.join(query))
+                execute(cursor, query)
 
-        # CREATE INDICIES
-        for table, columns in self.database_tables.items():
-            for column, v in columns.items():
-                if not v.get('indexed'):
-                    continue
-                query = 'CREATE INDEX IF NOT EXISTS {table}_{column}_x ON {table}({column})'.format(table=table, column=column)
-                try:
-                    cursor.execute(query)
-                except Exception as error:
-                    self.kodi_log(f'CACHE: Exception while initializing _database: {error}\n{self._sc_name} - {query}', 1)
+            # CREATE INDICIES
+            for table, columns in self.database_tables.items():
+                for column, v in columns.items():
+                    if not v.get('indexed'):
+                        continue
+                    query = 'CREATE INDEX IF NOT EXISTS {table}_{column}_x ON {table}({column})'.format(table=table, column=column)
+                    execute(cursor, query)
 
-        # DO SOME DATABASE MAINTAINENCE IF DB VERSION INCREASED
-        if this_database_version < self.database_version:
-            # UPDATE DATABASE VERSION
-            try:
+            # DO SOME DATABASE MAINTENENCE IF DB VERSION INCREASED
+            if this_database_version < self.database_version:
+                # UPDATE DATABASE VERSION
                 query = f"PRAGMA user_version = {self.database_version}"
-                cursor.execute(query)
-            except Exception as error:
-                self.kodi_log(f'CACHE: Exception while initializing _database: {error}\n{self._sc_name} - {query}', 1)
-
-        return connection
+                execute(cursor, query)
+        finally:
+            cursor.close()
 
 
 class DatabaseStatements:
@@ -278,7 +344,7 @@ class DatabaseMethod:
             values,
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def get_list_values(self, table=DEFAULT_TABLE, keys=(), values=(), conditions=None, connection=None):
         cursor = self.execute_sql(
@@ -290,9 +356,11 @@ class DatabaseMethod:
         if not cursor:
             return
 
-        data = cursor.fetchall()
-        if not connection and cursor:
-            cursor.close()
+        try:
+            data = cursor.fetchall()
+        finally:
+            if not connection:
+                self.close_cursor(cursor, close_connection=True)
 
         return data
 
@@ -302,7 +370,7 @@ class DatabaseMethod:
             data=values,
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def set_or_update_null_list_values(self, table=DEFAULT_TABLE, keys=(), values=(), conflict_constraint='id', connection=None):
         if not values:
@@ -313,7 +381,7 @@ class DatabaseMethod:
             values,
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def get_values(self, table=DEFAULT_TABLE, item_id=None, keys=(), connection=None):
         cursor = self.execute_sql(
@@ -325,9 +393,11 @@ class DatabaseMethod:
         if not cursor:
             return
 
-        data = cursor.fetchone()
-        if not connection and cursor:
-            cursor.close()
+        try:
+            data = cursor.fetchone()
+        finally:
+            if not connection:
+                self.close_cursor(cursor, close_connection=True)
 
         return data
 
@@ -343,7 +413,7 @@ class DatabaseMethod:
             data=(*values, item_id, ),
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def set_many_values(self, table=DEFAULT_TABLE, keys=(), data=None, connection=None):
         """ data={item_id: ((key, value), (key, value))} """
@@ -359,7 +429,7 @@ class DatabaseMethod:
             data=[(*values, item_id, ) for item_id, values in data.items()],
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def del_column_values(self, table=DEFAULT_TABLE, keys=(), item_type=None, connection=None):
         cursor = self.execute_sql(
@@ -369,7 +439,7 @@ class DatabaseMethod:
             data=None if item_type is None else (item_type, ),
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def del_item(self, table=DEFAULT_TABLE, item_id=None, connection=None):
         cursor = self.execute_sql(
@@ -377,7 +447,7 @@ class DatabaseMethod:
             data=(item_id, ),
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def del_item_like(self, table=DEFAULT_TABLE, item_id=None, connection=None):
         cursor = self.execute_sql(
@@ -385,7 +455,7 @@ class DatabaseMethod:
             data=(item_id, ),
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def create_item(self, table=DEFAULT_TABLE, item_id=None, connection=None):
         cursor = self.execute_sql(
@@ -393,7 +463,7 @@ class DatabaseMethod:
             data=(item_id,),
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
     def create_many_items(self, table=DEFAULT_TABLE, item_ids=(), connection=None):
         cursor = self.execute_sql(
@@ -401,7 +471,7 @@ class DatabaseMethod:
             data=[(item_id,) for item_id in item_ids],
             connection=connection)
         if not connection and cursor:
-            cursor.close()
+            self.close_cursor(cursor, close_connection=True)
 
 
 class Database(DatabaseCore, DatabaseMethod):

--- a/resources/tmdbhelper/lib/files/dbfunc.py
+++ b/resources/tmdbhelper/lib/files/dbfunc.py
@@ -1,37 +1,62 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from jurialmunkey.ftools import cached_property
+from jurialmunkey.ftools import threaded_cached_property
 from contextlib import contextmanager
+from threading import local
 
 
 class DatabaseConnection:
-    open_connection = None
-
     def __init__(self, cache):
         self.cache = cache
+        self._local = local()
+
+    @property
+    def open_connection(self):
+        return getattr(self._local, 'cursor', None)
+
+    @property
+    def database_connection(self):
+        return getattr(self._local, 'connection', None)
 
     def close(self):
-        if not self.open_connection:
-            return
-        self.open_connection.close()
-        self.open_connection = None
+        cursor = self.open_connection
+        connection = self.database_connection
+
+        try:
+            if cursor:
+                cursor.close()
+        finally:
+            try:
+                if connection:
+                    connection.close()
+            finally:
+                self._local.cursor = None
+                self._local.connection = None
 
     @contextmanager
     def open(self):
-        existing_connection = bool(self.open_connection)
+        existing_connection = self.open_connection
 
-        if not existing_connection:
-            self.open_connection = self.cache.get_database().cursor()
+        if existing_connection:
+            yield existing_connection
+            return
 
-        yield self.open_connection
+        connection = self.cache.get_database()
+        if not connection:
+            raise RuntimeError('Unable to open database connection')
 
-        if not existing_connection:
+        self._local.connection = connection
+        try:
+            self._local.cursor = connection.cursor()
+            with connection:
+                yield self.open_connection
+        finally:
             self.close()
 
 
 class DatabaseAccess:
 
-    @cached_property
+    @threaded_cached_property
     def connection(self):
         return DatabaseConnection(self.cache)
 

--- a/resources/tmdbhelper/lib/items/database/basedata.py
+++ b/resources/tmdbhelper/lib/items/database/basedata.py
@@ -1,4 +1,4 @@
-from jurialmunkey.ftools import cached_property
+from jurialmunkey.ftools import cached_property, threaded_cached_property
 from tmdbhelper.lib.files.dbfunc import DatabaseAccess
 from tmdbhelper.lib.addon.tmdate import set_timestamp
 from tmdbhelper.lib.api.contains import CommonContainerAPIs
@@ -18,7 +18,7 @@ class ItemDetailsDatabaseAccess(DatabaseAccess):
     def __init__(self, common_apis=None):
         self.common_apis = common_apis or CommonContainerAPIs()
 
-    @cached_property
+    @threaded_cached_property
     def cache(self):
         from tmdbhelper.lib.items.database.database import ItemDetailsDatabase
         return ItemDetailsDatabase()

--- a/resources/tmdbhelper/lib/items/database/listitem.py
+++ b/resources/tmdbhelper/lib/items/database/listitem.py
@@ -1,6 +1,6 @@
 from tmdbhelper.lib.api.contains import CommonContainerAPIs
 from tmdbhelper.lib.items.database.baseitem_factories.factory import BaseItemFactory
-from jurialmunkey.ftools import cached_property
+from jurialmunkey.ftools import cached_property, threaded_cached_property
 from tmdbhelper.lib.items.listitem import ListItem
 from tmdbhelper.lib.addon.plugin import convert_type
 from tmdbhelper.lib.items.database.database import ItemDetailsDatabase
@@ -286,7 +286,7 @@ class ListItemDetails:
         self.common_apis = common_apis or CommonContainerAPIs()
         self.cache = ItemDetailsDatabase()
 
-    @cached_property
+    @threaded_cached_property
     def connection(self):
         return DatabaseConnection(self.cache)
 

--- a/resources/tmdbhelper/lib/query/database/database.py
+++ b/resources/tmdbhelper/lib/query/database/database.py
@@ -1,6 +1,6 @@
 from tmdbhelper.lib.files.dbdata import Database
 from tmdbhelper.lib.files.dbfunc import DatabaseAccess
-from jurialmunkey.ftools import cached_property
+from jurialmunkey.ftools import cached_property, threaded_cached_property
 from tmdbhelper.lib.addon.tmdate import set_timestamp
 from tmdbhelper.lib.addon.consts import DEFAULT_EXPIRY
 from tmdbhelper.lib.query.database.genres import FindQueriesDatabaseGenres
@@ -111,7 +111,7 @@ class FindQueriesDatabase(
         from tmdbhelper.lib.api.tmdb.users import TMDbUser
         return TMDbUser()
 
-    @cached_property
+    @threaded_cached_property
     def access(self):
         access = DatabaseAccess()
         access.cache = self

--- a/resources/tmdbhelper/lib/script/method/maintenance.py
+++ b/resources/tmdbhelper/lib/script/method/maintenance.py
@@ -89,8 +89,8 @@ class DatabaseMaintenance:
         from tmdbhelper.lib.items.database.database import ItemDetailsDatabase
         from tmdbhelper.lib.query.database.database import FindQueriesDatabase
         with TimerFunc('Vacuuming databases:', inline=True):
-            ItemDetailsDatabase().execute_sql("VACUUM")
-            FindQueriesDatabase().execute_sql("VACUUM")
+            ItemDetailsDatabase().execute_sql_and_close("VACUUM")
+            FindQueriesDatabase().execute_sql_and_close("VACUUM")
 
     def delete_legacy_folders(self, force=False):
         """ Once-off routine to delete old unused database versions to avoid wasting disk space """

--- a/resources/tmdbhelper/lib/script/method/tmdb.py
+++ b/resources/tmdbhelper/lib/script/method/tmdb.py
@@ -96,13 +96,13 @@ def delete_itemtype(mediatype=None, confirmation=True, **kwargs):
             for i in routes[mediatype]['baseitems']:
                 statement = f'DELETE FROM baseitem WHERE mediatype="{i}"'
                 progress_dialog.update(statement)
-                database.execute_sql(statement)
+                database.execute_sql_and_close(statement)
             for i in routes[mediatype]['tables']:
                 statement = f'DELETE FROM {i}'
                 progress_dialog.update(statement)
-                database.execute_sql(statement)
+                database.execute_sql_and_close(statement)
             progress_dialog.update('Vacuuming database...')
-            database.execute_sql('VACUUM')
+            database.execute_sql_and_close('VACUUM')
 
     if confirmation:
         head = get_localized(32387).format(mediatype.capitalize())


### PR DESCRIPTION
TMDb Helper was intermittently crashing Kodi during startup. The logs showed SQLite objects being created in one thread and then used from another; on my Kodi CoreELEC devices, this frequently ended in a SIGSEGV inside _sqlite3.so, causing Kodi to frequently crash and restart ~10-15sec after startup.

TMDb Helper cached a SQLite cursor on an object shared by multiple worker threads. It also closed the cursor without reliably closing its underlying connection, leaving cleanup to Python.

Each thread now gets its own cursor and connection. Both are always closed, failed transactions roll back, and database initialization safely handles interrupted migrations.

This fixes the underlying SQLite ownership problem instead of bypassing it with check_same_thread=False.