### PR TITLE
Fix non-dictionary values in Trakt stats

### DIFF
--- a/resources/tmdbhelper/lib/query/database/trakt_stats.py
+++ b/resources/tmdbhelper/lib/query/database/trakt_stats.py
@@ -78,6 +78,7 @@ class GetTraktStatsRequest:
                 'stat': item_v,
             }
             for base_k, base_v in self.response_json.items()
+            if isinstance(base_v, dict)
             for item_k, item_v in base_v.items()
             if isinstance(item_v, int)
         ] if self.response_json else []

--- a/tests/test_trakt_stats.py
+++ b/tests/test_trakt_stats.py
@@ -1,0 +1,38 @@
+import functools
+import pathlib
+import runpy
+import sys
+import types
+import unittest
+
+
+class TestGetTraktStatsRequest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        ftools = types.ModuleType('jurialmunkey.ftools')
+        setattr(ftools, 'cached_property', functools.cached_property)
+        package = types.ModuleType('jurialmunkey')
+        setattr(package, 'ftools', ftools)
+        sys.modules['jurialmunkey'] = package
+        sys.modules['jurialmunkey.ftools'] = ftools
+
+        path = pathlib.Path(
+            'resources/tmdbhelper/lib/query/database/trakt_stats.py')
+        cls.request_type = runpy.run_path(str(path))['GetTraktStatsRequest']
+
+    def test_items_ignores_non_mapping_response_values(self):
+        request = object.__new__(self.request_type)
+        request.__dict__['response_json'] = {
+            'movies': {'watched': 3, 'collected': 2},
+            'account': 'jsox79',
+        }
+
+        self.assertEqual(request.items, [
+            {'name': 'watched', 'type': 'movies', 'stat': 3},
+            {'name': 'collected', 'type': 'movies', 'stat': 2},
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #1842

Trakt stats responses can include scalar top-level metadata alongside stat dictionaries. Ignore those scalar values instead of calling `.items()` on them; the regression test covers a mixed mapping-and-string response.

Tested with `python3 -m unittest -v tests/test_trakt_stats.py`.
