### PR TITLE
✨ Allow option to input user Trakt Client ID and Secret Key

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -2892,6 +2892,26 @@ msgid "You must authenticate your Trakt account to use this feature."
 msgstr ""
 
 #: /resources/settings.xml
+msgctxt "#32403"
+msgid "User Client ID"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32408"
+msgid "User Client Secret Key"
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32417"
+msgid "Enter your personal Trakt Client ID or leave blank to use the default TMDbHelper credentials. Re-authenticate your Trakt account for changes to take effect."
+msgstr ""
+
+#: /resources/settings.xml
+msgctxt "#32450"
+msgid "Enter your personal Trakt Client Secret Key or leave blank to use the default TMDbHelper credentials. Re-authenticate your Trakt account for changes to take effect."
+msgstr ""
+
+#: /resources/settings.xml
 msgctxt "#32014"
 msgid "Players"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -556,6 +556,40 @@
                     <visible>false</visible>
                     <enable>false</enable>
                 </setting>
+                <setting id="trakt_apikey" type="string" label="32403" help="32417">
+                    <level>0</level>
+                    <default/>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>32403</heading>
+                    </control>
+                </setting>
+                <setting id="trakt_apikey_access" type="boolean" label="32483" help="" parent="trakt_apikey">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                    <visible>false</visible>
+                    <enable>false</enable>
+                </setting>
+                <setting id="trakt_secret" type="string" label="32408" help="32450">
+                    <level>0</level>
+                    <default/>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="edit" format="string">
+                        <heading>32408</heading>
+                    </control>
+                </setting>
+                <setting id="trakt_secret_access" type="boolean" label="32483" help="" parent="trakt_secret">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                    <visible>false</visible>
+                    <enable>false</enable>
+                </setting>
                 <setting id="revoke_trakt" type="action" label="32169" help="">
                     <level>0</level>
                     <data>RunScript(plugin.video.themoviedb.helper,revoke_trakt)</data>

--- a/resources/tmdbhelper/lib/api/api_keys/trakt.py
+++ b/resources/tmdbhelper/lib/api/api_keys/trakt.py
@@ -1,9 +1,16 @@
 from tmdbhelper.lib.addon.permissions import __access__
 from tmdbhelper.lib.api.api_keys.tokenhandler import TokenHandler
+from tmdbhelper.lib.addon.plugin import get_setting
+
+DEFAULT_CLIENT_ID = 'e6fde6173adf3c6af8fd1b0694b9b84d7c519cefc24482310e1de06c6abe5467'
+DEFAULT_CLIENT_SECRET = '15119384341d9a61c751d8d515acbc0dd801001d4ebe85d3eef9885df80ee4d9'
+
+USER_CLIENT_ID = get_setting('trakt_apikey', 'str')
+USER_CLIENT_SECRET = get_setting('trakt_secret', 'str')
 
 if __access__.has_access('internal'):
-    CLIENT_ID = 'e6fde6173adf3c6af8fd1b0694b9b84d7c519cefc24482310e1de06c6abe5467'
-    CLIENT_SECRET = '15119384341d9a61c751d8d515acbc0dd801001d4ebe85d3eef9885df80ee4d9'
+    CLIENT_ID = USER_CLIENT_ID or DEFAULT_CLIENT_ID
+    CLIENT_SECRET = USER_CLIENT_SECRET or DEFAULT_CLIENT_SECRET
     USER_TOKEN = TokenHandler('trakt_token', store_as='setting')
 
 elif __access__.has_access('trakt'):


### PR DESCRIPTION
Need to re-authenticate for the new credentials to take effect.

Can move the setting to the API section if required, but the dedicated Trakt category made more sense.

---

Hey J!

I know you already said that you weren't interested in working on any new Trakt features (or any band-aid workarounds) but I felt this was easy enough to add so decided to make a PR anyway haha.

I haven't had the time to migrate my personal setup over to MDBList, so I'm still hanging on by a thread lol 🤣 

Thank you for your time!