### PR TITLE
Fix: OSD poster display

### DIFF
--- a/resources/tmdbhelper/lib/items/directories/base/lists_details.py
+++ b/resources/tmdbhelper/lib/items/directories/base/lists_details.py
@@ -5,11 +5,17 @@ from jurialmunkey.ftools import cached_property
 
 class ItemDetails:
     def __init__(self, directory, tmdb_type, tmdb_id, season=None, episode=None):
-        self.directory = directory  # Directory container class instance
+        self.directory = directory
         self.tmdb_type = tmdb_type
         self.tmdb_id = tmdb_id
-        self.season = season
-        self.episode = episode
+        self._season = season
+        self._episode = episode
+        if tmdb_type == 'tv' and season is not None and episode is not None:
+            self.season = None
+            self.episode = None
+        else:
+            self.season = season
+            self.episode = episode
 
     @property
     def lidc(self):
@@ -26,12 +32,10 @@ class ItemDetails:
             'tmdb_type': self.tmdb_type,
             'tmdb_id': self.tmdb_id
         }
-        if self.season is None:
-            return params
-        params['season'] = self.season
-        if self.episode is None:
-            return params
-        params['episode'] = self.episode
+        if self.season is not None:
+            params['season'] = self.season
+        if self.episode is not None:
+            params['episode'] = self.episode
         return params
 
     @cached_property
@@ -54,6 +58,9 @@ class ListDetails(ContainerDirectory):
     is_cacheonly = False
 
     def get_items(self, tmdb_type, tmdb_id, season=None, episode=None, **kwargs):
+        if tmdb_type == 'tv' and season is not None and episode is not None:
+            season = None
+            episode = None
         self.kodi_db = self.get_kodi_database(tmdb_type)
         self.container_content = convert_type(tmdb_type, output='container', season=season, episode=episode)
         return ItemDetails(self, tmdb_type, tmdb_id, season, episode).itemlist


### PR DESCRIPTION
The issue is that the OSD call passes extra 
"season" and 
"episode" parameters, causing the plugin to return an 
"episode" type (single episode), whose artwork only includes a landscape still.

However, when browsing externally without passing these two parameters, it returns a 
"tvshow" type with the correct vertical poster.

Modification Plan

Only one core file, 
"lists_details.py", was modified:

In 
"ListDetails.get_items()" and 
"ItemDetails.__init__()", when 
"tmdb_type='tv'" and both 
"season" and 
"episode" parameters are passed simultaneously, these two parameters are directly ignored (set to 
"None"). This way:

* 
"self.lidc.get_item('tv', tmdb_id, None, None)" retrieves the details of the entire TV show (tvshow), exactly the same as clicking details externally.
* The returned 
"mediatype='tvshow'" (not 
"episode"), and the 
"art" contains the correct vertical 
"poster".
* Kodi opens the TV show information dialog, and the poster area normally displays the vertical poster.
* 
"container_content" is also 
"tvshows", consistent with the external details page.

At the same time, the defensive modification in 
"listitem.py"'s 
"_Episode" class (falling back 
"poster" to 
"tvshow.poster") has been retained as a safety net for other scenarios.

<img width="485" height="688" alt="Screenshot_2026-07-26-23-02-31-306_com tencent mobileqq" src="https://github.com/user-attachments/assets/5d887cb1-c23d-4dfd-a7a5-6b3e458f4fcd" />
<img width="1385" height="727" alt="Image_1785117183648_774" src="https://github.com/user-attachments/assets/c089682e-82b0-48dc-a2c1-06e78d1567c8" />
<img width="4096" height="3072" alt="IMG_20260726_222249" src="https://github.com/user-attachments/assets/48ffaaaa-2266-4580-bc49-75e267230b95" />
