### PR TITLE
🐛 Skip non-dict values in Trakt stats

### DIFF
--- a/resources/tmdbhelper/lib/query/database/trakt_stats.py
+++ b/resources/tmdbhelper/lib/query/database/trakt_stats.py
@@ -78,6 +78,7 @@ class GetTraktStatsRequest:
                 'stat': item_v,
             }
             for base_k, base_v in self.response_json.items()
+            if isinstance(base_v, dict)
             for item_k, item_v in base_v.items()
             if isinstance(item_v, int)
         ] if self.response_json else []


### PR DESCRIPTION
Hey Jurial,

Hope you're doing well — thanks for all the work on this addon.

Trakt have added three **integer** fields to the top level of `/users/me/stats`, alongside the dicts that were always there:

```
movies  dict          network dict          lists          8
shows   dict          ratings dict          total_minutes  260358
seasons dict          progress dict         total_plays    4511
episodes dict
```

`GetTraktStatsRequest.items` iterates every top-level value as a dict, so it now raises:

```
AttributeError: 'int' object has no attribute 'items'
```

The `isinstance` guard is already there, but on the inner loop — one level below where the new fields sit:

https://github.com/jurialmunkey/plugin.video.themoviedb.helper/blob/18f578505de56c72e2cf3935ee5931f4dd41b4c8/resources/tmdbhelper/lib/query/database/trakt_stats.py#L72-L85

### Why this is worth more than the traceback suggests

The exception surfaces inside `Scrobbler.stop()`, at the last step:

```python
def stop(self, tmdb_type, tmdb_id):
    if not self.started or self.stopped:
        return
    kodi_log(f'SCROBBLER: [Stop] {self.content_id} -- {self.progress:.2f}%', 2)
    self.trakt_scrobbling('stop') if not self.syncing else None
    self.set_kodi_watched()
    self.set_tmdb_ratings()
    self.update_stats()   # <-- raises here
    self.stopped = True   # <-- never reached
```

`stop()` never completes and `self.stopped` stays `False`, so the monitor holds on to the previous item. The next playback then scrobbles the **previous** title. On my box that produced this, sent while a completely different film was playing:

```
Postdata: {'movie': {'ids': {'tmdb': '1119449'}}, 'progress': 86.6446567841814}
```

Because 86.6% is past Trakt's 80% threshold, the wrong film was marked watched and lost its resume point — it was only 12% watched — while the film actually playing recorded nothing at all. It presents to the user as "a movie disappeared from Continue Watching" and "progress stopped updating", with no visible error.

### Fix

Guard the outer loop as well. Verified against the live response from my account: parses the seven dict sections, skips the three integers, no exception.

Happy to adjust the approach if you'd prefer it handled somewhere else — e.g. normalising the response before it reaches this comprehension.
