### PR TITLE
Add rate-limited scrobble heartbeat

### DIFF
--- a/resources/tmdbhelper/lib/monitor/player.py
+++ b/resources/tmdbhelper/lib/monitor/player.py
@@ -278,6 +278,21 @@ class PlayerMonitor(Player, CommonMonitorFunctions):
         self.scrobbler_update()
         self.scrobbler.sync(self.tmdb_type, self.tmdb_id)
 
+    def scrobbler_heartbeat(self, force=False, background=True):
+        if not self.scrobbler or not self.isPlayingVideo():
+            return
+        if not self.scrobbler.heartbeat_due(force=force):
+            return
+        if not force and get_condvisibility("Player.Paused"):
+            return
+        self.scrobbler_update()
+        self.scrobbler.heartbeat(
+            self.tmdb_type,
+            self.tmdb_id,
+            force=force,
+            background=background,
+        )
+
     def scrobbler_update(self):
         if not self.scrobbler or not self.isPlayingVideo():
             return
@@ -407,7 +422,13 @@ class PlayerMonitor(Player, CommonMonitorFunctions):
         self.previous_fanart = None
 
     def on_fullscreen(self):
+        self.scrobbler_heartbeat()
         self.scrobbler_sync()
+
+    def on_service_exit(self):
+        if self.scrobbler:
+            self.scrobbler.wait_for_heartbeat()
+        self.scrobbler_heartbeat(force=True, background=False)
 
     def get_playingitem(self):
         # Check that video other than dummy splash video is playing

--- a/resources/tmdbhelper/lib/monitor/scrobbler.py
+++ b/resources/tmdbhelper/lib/monitor/scrobbler.py
@@ -1,9 +1,15 @@
 from jurialmunkey.window import get_property
 from jurialmunkey.ftools import cached_property
 from jurialmunkey.parser import try_int
+from threading import RLock
+from time import monotonic
 from tmdbhelper.lib.addon.plugin import get_setting
 from tmdbhelper.lib.addon.logger import kodi_log
 from tmdbhelper.lib.addon.tmdate import set_timestamp
+from tmdbhelper.lib.addon.thread import SafeThread
+
+
+SCROBBLE_HEARTBEAT_INTERVAL = 300
 
 
 class PlayerScrobbler():
@@ -21,6 +27,10 @@ class PlayerScrobbler():
         self.stopped = False
         self.started = False
         self.syncing = False
+        self._heartbeat_inflight = False
+        self._heartbeat_last = None
+        self._heartbeat_thread = None
+        self._scrobble_lock = RLock()
 
     def playerstring_get_tmdb_type(self):
         tmdb_type = self.playerstring.get('tmdb_type')
@@ -153,26 +163,66 @@ class PlayerScrobbler():
     def scrobble(self, method):
         if method not in ('start', 'stop'):
             return
-        if self.is_trakt_authorized:
-            self.trakt_scrobbler_item['progress'] = self.progress
-            path = f'https://api.trakt.tv/scrobble/{method}'
-            data = self.trakt_api.get_api_request(
-                path,
-                postdata=self.trakt_scrobbler_item,
-                headers=self.trakt_api.headers,
-                method='json'
-            )
-            kodi_log(f'SCROBBLER: [TRAKT] [{method}] {self.content_id} -- {self.progress:.2f}%\n{self.trakt_scrobbler_item}\n{data}', 2)
-        if self.is_mdblist_authorized:
-            self.mdblist_scrobbler_item['progress'] = try_int(self.progress)
-            path = self.mdblist_api.get_request_url('scrobble', method)
-            data = self.mdblist_api.get_simple_api_request(
-                path,
-                postdata=self.mdblist_scrobbler_item,
-                headers=self.mdblist_api.headers,
-                method='json'
-            )
-            kodi_log(f'SCROBBLER: [MDBLIST] [{method}] {self.content_id} -- {self.progress:.2f}%\n{self.mdblist_scrobbler_item}\n{data}', 2)
+        with self._scrobble_lock:
+            if self.stopped:
+                return
+            if self.is_trakt_authorized:
+                self.trakt_scrobbler_item['progress'] = self.progress
+                path = f'https://api.trakt.tv/scrobble/{method}'
+                data = self.trakt_api.get_api_request(
+                    path,
+                    postdata=self.trakt_scrobbler_item,
+                    headers=self.trakt_api.headers,
+                    method='json'
+                )
+                kodi_log(f'SCROBBLER: [TRAKT] [{method}] {self.content_id} -- {self.progress:.2f}%\n{self.trakt_scrobbler_item}\n{data}', 2)
+            if self.is_mdblist_authorized:
+                self.mdblist_scrobbler_item['progress'] = try_int(self.progress)
+                path = self.mdblist_api.get_request_url('scrobble', method)
+                data = self.mdblist_api.get_simple_api_request(
+                    path,
+                    postdata=self.mdblist_scrobbler_item,
+                    headers=self.mdblist_api.headers,
+                    method='json'
+                )
+                kodi_log(f'SCROBBLER: [MDBLIST] [{method}] {self.content_id} -- {self.progress:.2f}%\n{self.mdblist_scrobbler_item}\n{data}', 2)
+
+    def heartbeat_due(self, current_time=None, force=False):
+        if not self.started or self.stopped or self.syncing:
+            return False
+        if self._heartbeat_inflight:
+            return False
+        if force or self._heartbeat_last is None:
+            return True
+        current_time = monotonic() if current_time is None else current_time
+        return current_time - self._heartbeat_last >= SCROBBLE_HEARTBEAT_INTERVAL
+
+    def _heartbeat_worker(self):
+        try:
+            self.scrobble('start')
+        finally:
+            self._heartbeat_inflight = False
+
+    def wait_for_heartbeat(self, timeout=5):
+        if not self._heartbeat_thread or not self._heartbeat_inflight:
+            return
+        self._heartbeat_thread.join(timeout)
+
+    @is_scrobbling
+    def heartbeat(self, tmdb_type, tmdb_id, force=False, background=True):
+        if not self.is_match(tmdb_type, tmdb_id):
+            return False
+        current_time = monotonic()
+        if not self.heartbeat_due(current_time=current_time, force=force):
+            return False
+        self._heartbeat_last = current_time
+        self._heartbeat_inflight = True
+        if not background:
+            self._heartbeat_worker()
+            return True
+        self._heartbeat_thread = SafeThread(target=self._heartbeat_worker)
+        self._heartbeat_thread.start()
+        return True
 
     @is_scrobbling
     def start(self, tmdb_type, tmdb_id):
@@ -182,6 +232,7 @@ class PlayerScrobbler():
             return self.stop(tmdb_type, tmdb_id)
         self.scrobble('start')
         self.started = True
+        self._heartbeat_last = monotonic()
 
     @is_scrobbling
     def pause(self, tmdb_type, tmdb_id):
@@ -191,12 +242,15 @@ class PlayerScrobbler():
     def stop(self, tmdb_type, tmdb_id):
         if not self.started or self.stopped:
             return
-        kodi_log(f'SCROBBLER: [Stop] {self.content_id} -- {self.progress:.2f}%', 2)
-        self.scrobble('stop') if not self.syncing else None
-        self.set_kodi_watched()
-        self.set_tmdb_ratings()
-        self.update_stats()
-        self.stopped = True
+        with self._scrobble_lock:
+            if self.stopped:
+                return
+            kodi_log(f'SCROBBLER: [Stop] {self.content_id} -- {self.progress:.2f}%', 2)
+            self.scrobble('stop') if not self.syncing else None
+            self.set_kodi_watched()
+            self.set_tmdb_ratings()
+            self.update_stats()
+            self.stopped = True
 
     @is_scrobbling
     def sync(self, tmdb_type, tmdb_id):

--- a/resources/tmdbhelper/lib/monitor/service.py
+++ b/resources/tmdbhelper/lib/monitor/service.py
@@ -66,6 +66,10 @@ class ServiceMonitor(Poller):
 
     def _on_exit(self):
         try:
+            self.player_monitor.on_service_exit()
+        except Exception:
+            pass
+        try:
             self.cron_job.exit = True
         except AttributeError:
             pass

--- a/tests/test_scrobbler_heartbeat.py
+++ b/tests/test_scrobbler_heartbeat.py
@@ -1,0 +1,132 @@
+import functools
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+ROOT = pathlib.Path(__file__).parents[1]
+SCROBBLER_PATH = ROOT / "resources" / "tmdbhelper" / "lib" / "monitor" / "scrobbler.py"
+
+
+def stub_module(name, **attributes):
+    module = types.ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+
+
+stub_module("jurialmunkey")
+stub_module("jurialmunkey.window", get_property=lambda *args, **kwargs: 1)
+stub_module("jurialmunkey.ftools", cached_property=functools.cached_property)
+stub_module("jurialmunkey.parser", try_int=int)
+stub_module("tmdbhelper")
+stub_module("tmdbhelper.lib")
+stub_module("tmdbhelper.lib.addon")
+stub_module("tmdbhelper.lib.addon.plugin", get_setting=lambda *args, **kwargs: True)
+stub_module("tmdbhelper.lib.addon.logger", kodi_log=lambda *args, **kwargs: None)
+stub_module("tmdbhelper.lib.addon.tmdate", set_timestamp=lambda value=0: value)
+
+
+class DeferredThread:
+    instances = []
+
+    def __init__(self, target):
+        self.target = target
+        self.started = False
+        self.joined = False
+        self.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def join(self, timeout=None):
+        self.joined = True
+
+
+stub_module("tmdbhelper.lib.addon.thread", SafeThread=DeferredThread)
+
+spec = importlib.util.spec_from_file_location("heartbeat_scrobbler", SCROBBLER_PATH)
+scrobbler_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scrobbler_module)
+PlayerScrobbler = scrobbler_module.PlayerScrobbler
+
+
+class HeartbeatScrobbler(PlayerScrobbler):
+    def __init__(self):
+        self.tmdb_type = "movie"
+        self.tmdb_id = 1081003
+        self.total_time = 6000
+        self.started = True
+        self.stopped = False
+        self.syncing = False
+        self._heartbeat_inflight = False
+        self._heartbeat_last = 1000
+        self._heartbeat_thread = None
+        self.scrobble = Mock()
+
+
+class TestHeartbeat(unittest.TestCase):
+    def setUp(self):
+        DeferredThread.instances.clear()
+        self.scrobbler = HeartbeatScrobbler()
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1299)
+    def test_does_not_send_before_interval(self, _monotonic):
+        self.assertFalse(self.scrobbler.heartbeat("movie", 1081003))
+        self.scrobbler.scrobble.assert_not_called()
+        self.assertEqual([], DeferredThread.instances)
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1300)
+    def test_schedules_background_heartbeat_at_interval(self, _monotonic):
+        self.assertTrue(self.scrobbler.heartbeat("movie", 1081003))
+        self.assertEqual(1, len(DeferredThread.instances))
+        self.assertTrue(DeferredThread.instances[0].started)
+        self.assertTrue(self.scrobbler._heartbeat_inflight)
+        self.scrobbler.scrobble.assert_not_called()
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1600)
+    def test_allows_only_one_inflight_request(self, _monotonic):
+        self.assertTrue(self.scrobbler.heartbeat("movie", 1081003))
+        self.assertFalse(self.scrobbler.heartbeat("movie", 1081003))
+        self.assertEqual(1, len(DeferredThread.instances))
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1300)
+    def test_worker_sends_start_and_releases_inflight_guard(self, _monotonic):
+        self.assertTrue(self.scrobbler.heartbeat("movie", 1081003))
+        DeferredThread.instances[0].target()
+        self.scrobbler.scrobble.assert_called_once_with("start")
+        self.assertFalse(self.scrobbler._heartbeat_inflight)
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1300)
+    def test_shutdown_can_wait_for_inflight_heartbeat(self, _monotonic):
+        self.assertTrue(self.scrobbler.heartbeat("movie", 1081003))
+        self.scrobbler.wait_for_heartbeat(timeout=3)
+        self.assertTrue(DeferredThread.instances[0].joined)
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1001)
+    def test_force_flush_runs_synchronously(self, _monotonic):
+        self.assertTrue(self.scrobbler.heartbeat("movie", 1081003, force=True, background=False))
+        self.scrobbler.scrobble.assert_called_once_with("start")
+        self.assertFalse(self.scrobbler._heartbeat_inflight)
+        self.assertEqual([], DeferredThread.instances)
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1600)
+    def test_stopped_or_synced_playback_never_heartbeats(self, _monotonic):
+        self.scrobbler.stopped = True
+        self.assertFalse(self.scrobbler.heartbeat("movie", 1081003))
+        self.scrobbler.stopped = False
+        self.scrobbler.syncing = True
+        self.assertFalse(self.scrobbler.heartbeat("movie", 1081003))
+        self.scrobbler.scrobble.assert_not_called()
+
+    @patch.object(scrobbler_module, "monotonic", return_value=1600)
+    def test_mismatched_item_never_heartbeats(self, _monotonic):
+        self.assertFalse(self.scrobbler.heartbeat("movie", 999))
+        self.scrobbler.scrobble.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- checkpoint active Trakt/MDbList scrobbles every five minutes
- run heartbeat requests on a background thread with one-request-in-flight protection
- serialize heartbeat and stop requests to avoid lifecycle races
- flush current progress during an orderly service shutdown
- skip heartbeat work while paused, stopped, synced, or on a mismatched item

## Why

TMDb Helper previously sent a scrobble only at playback start and stop. If Kodi exited or crashed before the stop callback, Trakt retained no useful playback position and the item disappeared from in-progress widgets.

The service already polls during fullscreen playback. The new hot path performs only a monotonic timestamp comparison; playback time is read and the API is contacted only when the five-minute interval is due. Network work is isolated from Kodi's playback and UI thread.

## Validation

- 8 focused heartbeat lifecycle/rate-limit tests pass
- Python compileall passes for the modified monitor modules and tests
- `git diff --check` passes
- deployed 6.16.2 backport loaded successfully in Kodi 21.3 without Python exceptions
