### PR TITLE
Fix ListItem.TotalEpisodes for in progress seasons / ListItem.UnwatchedEpisodes for in progress TV shows

### DIFF
--- a/resources/tmdbhelper/lib/items/listitem.py
+++ b/resources/tmdbhelper/lib/items/listitem.py
@@ -3,7 +3,7 @@ from jurialmunkey.ftools import cached_property
 from jurialmunkey.parser import try_int, merge_two_dicts, boolean
 from infotagger.listitem import ListItemInfoTag
 from tmdbhelper.lib.addon.consts import PARAM_WIDGETS_RELOAD, PARAM_WIDGETS_RELOAD_FORCED
-from tmdbhelper.lib.addon.plugin import ADDONPATH, PLUGINPATH, get_condvisibility, get_localized, encode_url, get_flatseasons_info_param, GlobalSettingsDict
+from tmdbhelper.lib.addon.plugin import ADDONPATH, PLUGINPATH, get_condvisibility, get_localized, encode_url, get_flatseasons_info_param, get_setting, GlobalSettingsDict
 from tmdbhelper.lib.addon.tmdate import is_unaired_timestamp
 from jurialmunkey.window import get_property
 
@@ -491,11 +491,11 @@ class _Tvshow(_Video):
         For tvshows and seasons have to hardcode playcount as a 0|1 boolean
         because Kodi treats it as watched/unwatched boolean for whole show
         """
-        if not self.airedepisodes:
+        if not self.totalepisodes:
             return 0
         if not self.watchedepisodes:
             return 0
-        if self.airedepisodes > self.watchedepisodes:
+        if self.totalepisodes > self.watchedepisodes:
             return 0
         return 1
 
@@ -512,22 +512,18 @@ class _Tvshow(_Video):
         return try_int(self.infoproperties.get('watchedepisodes'), fallback=0)
 
     @property
-    def airedepisodes(self):
-        return try_int(self.infoproperties.get('airedepisodes'), fallback=0)
-
-    @property
     def unwatchedepisodes(self):
-        if self.airedepisodes < self.watchedepisodes:
+        if self.totalepisodes < self.watchedepisodes:
             return 0
         if not self.watchedepisodes:
-            return self.airedepisodes or self.totalepisodes
-        return self.airedepisodes - self.watchedepisodes
+            return self.totalepisodes
+        return self.totalepisodes - self.watchedepisodes
 
     @property
     def watchedprogress(self):
-        if not self.airedepisodes:
+        if not self.totalepisodes:
             return
-        return int(self.watchedepisodes * 100 / self.airedepisodes)
+        return int(self.watchedepisodes * 100 / self.totalepisodes)
 
     def finalise_infoproperties(self):
         super().finalise_infoproperties()
@@ -582,6 +578,16 @@ class _Season(_Tvshow):
     @property
     def season(self):
         return self.infolabels.get('season')
+
+    @property
+    def airedepisodes(self):
+        return try_int(self.infoproperties.get('airedepisodes'), fallback=0)
+
+    @property
+    def totalepisodes(self):
+        if self.airedepisodes and get_setting('seasons_anticipated'):
+            return self.airedepisodes
+        return super().totalepisodes
 
     def get_context_menu_choosedefault_params(self):
         params = super().get_context_menu_choosedefault_params()


### PR DESCRIPTION
This PR is intended to fix the episode count for TV shows and seasons. It reverts the logic to calculate the number of unwatched episodes for TV shows back to use totalepisodes instead of airedepisodes which is not available for TV shows. For seasons the totalepisodes property is overriden to use airedepisodes when appropriate.

This fixes both #1829  and #1862 

Number of unwatched episodes is now 23 instead of 0:

<img width="3200" height="1800" alt="Trending today" src="https://github.com/user-attachments/assets/61e1053b-65cb-4f9d-b8b4-d5279c4421da" />

Epsiodes are now correctly split between aired and unaired:

<img width="3200" height="1800" alt="In Progress season" src="https://github.com/user-attachments/assets/3a0505b6-4d68-491b-b8dd-237a7ee8a568" />

The fix has also been tested with "Additional Season: Anticipated" disabled.