### PR TITLE
Add MDBList next episodes and watchlist views

### DIFF
--- a/resources/tmdbhelper/lib/addon/consts.py
+++ b/resources/tmdbhelper/lib/addon/consts.py
@@ -68,7 +68,15 @@ PLAYERS_BASEDIR_TEMPLATES = 'special://home/addons/plugin.video.themoviedb.helpe
 PLAYERS_PRIORITY = 1000
 PLAYERS_CHOSEN_DEFAULTS_FILENAME = 'player_defaults'
 
-NO_UNAIRED_LABEL = ('details', 'trakt_calendar', 'library_nextaired', 'videos', 'trakt_watchlist_anticipated', 'trakt_anticipated')
+NO_UNAIRED_LABEL = (
+    'details',
+    'trakt_calendar',
+    'library_nextaired',
+    'videos',
+    'trakt_watchlist_anticipated',
+    'mdblist_watchlist_anticipated',
+    'trakt_anticipated',
+)
 
 PARAM_WIDGETS_RELOAD = 'reload=$INFO[Window(Home).Property(TMDbHelper.Widgets.Reload)]'
 PARAM_WIDGETS_RELOAD_FORCED = 'reload=$INFO[System.Time(hh:mm:ss)]'
@@ -252,6 +260,18 @@ ROUTE_NOID = {
     'mdblist_sortby': {'route': {
         'module_name': 'tmdbhelper.lib.items.directories.mdblist.lists_sorting',
         'import_attr': 'ListMDbListSortBy'}},
+    'mdblist_watchlist': {'route': {
+        'module_name': 'tmdbhelper.lib.items.directories.mdblist.lists_sync',
+        'import_attr': 'ListMDbListWatchlist'}},
+    'mdblist_watchlist_released': {'route': {
+        'module_name': 'tmdbhelper.lib.items.directories.mdblist.lists_sync',
+        'import_attr': 'ListMDbListWatchlistReleased'}},
+    'mdblist_watchlist_anticipated': {'route': {
+        'module_name': 'tmdbhelper.lib.items.directories.mdblist.lists_sync',
+        'import_attr': 'ListMDbListWatchlistAnticipated'}},
+    'mdblist_nextepisodes': {'route': {
+        'module_name': 'tmdbhelper.lib.items.directories.mdblist.lists_sync',
+        'import_attr': 'ListMDbListNextEpisodes'}},
     'mdblist_locallist': {'route': {
         'module_name': 'tmdbhelper.lib.items.directories.mdblist.lists_local',
         'import_attr': 'ListMDbListLocal'}},

--- a/resources/tmdbhelper/lib/items/directories/base/basedir_mdblist.py
+++ b/resources/tmdbhelper/lib/items/directories/base/basedir_mdblist.py
@@ -1,4 +1,24 @@
 from tmdbhelper.lib.items.directories.base.basedir_item import BaseDirItem
+from tmdbhelper.lib.items.directories.base.item_builder import BaseDirItemBuilder
+from tmdbhelper.lib.addon.consts import RUNSCRIPT
+from jurialmunkey.ftools import cached_property
+
+
+class BaseDirItemMDbListBuilder(BaseDirItemBuilder):
+    @cached_property
+    def context_menu(self):
+        if not self.base_item.sorting:
+            return []
+        return [(
+            self.base_item.sort_label,
+            RUNSCRIPT.format('sort_mdblist,{}'.format(','.join(f'{k}={v}' for k, v in self.params.items())))
+        )]
+
+    @cached_property
+    def infoproperties(self):
+        infoproperties = super().infoproperties
+        infoproperties['is_sortable'] = 'mdblist' if self.base_item.sorting else None
+        return infoproperties
 
 
 class BaseDirItemMDbListTopLists(BaseDirItem):
@@ -13,6 +33,47 @@ class BaseDirItemMDbListTopLists(BaseDirItem):
     def enabled(self):
         from tmdbhelper.lib.addon.plugin import get_setting
         return bool(get_setting('mdblist_apikey', 'str'))
+
+
+class BaseDirItemMDbListWatchlist(BaseDirItemMDbListTopLists):
+    priority = 10
+    label_type = 'suffixed'
+    label_localized = 32193
+    label_suffix = '(MDbList)'
+    params = {'info': 'mdblist_watchlist'}
+    sorting = True
+    item_builder = BaseDirItemMDbListBuilder
+    art_icon = 'resources/icons/sync/watchlist.png'
+    types = ('movie', )
+    group = 32193
+
+    @cached_property
+    def sort_label(self):
+        from tmdbhelper.lib.addon.plugin import get_localized
+        return get_localized(32309)
+
+
+class BaseDirItemMDbListWatchlistReleased(BaseDirItemMDbListWatchlist):
+    priority = 20
+    label_localized = 32456
+    params = {'info': 'mdblist_watchlist_released'}
+
+
+class BaseDirItemMDbListWatchlistAnticipated(BaseDirItemMDbListWatchlist):
+    priority = 30
+    label_localized = 32457
+    params = {'info': 'mdblist_watchlist_anticipated'}
+
+
+class BaseDirItemMDbListNextEpisodes(BaseDirItemMDbListTopLists):
+    priority = 40
+    label_type = 'suffixed'
+    label_localized = 32197
+    label_suffix = '(MDbList)'
+    params = {'info': 'mdblist_nextepisodes'}
+    art_icon = 'resources/icons/trakt/inprogress.png'
+    types = ('tv', )
+    group = 32196
 
 
 class BaseDirItemMDbListYourLists(BaseDirItemMDbListTopLists):

--- a/resources/tmdbhelper/lib/items/directories/base/basedir_mdblist.py
+++ b/resources/tmdbhelper/lib/items/directories/base/basedir_mdblist.py
@@ -1,24 +1,6 @@
 from tmdbhelper.lib.items.directories.base.basedir_item import BaseDirItem
-from tmdbhelper.lib.items.directories.base.item_builder import BaseDirItemBuilder
-from tmdbhelper.lib.addon.consts import RUNSCRIPT
+from tmdbhelper.lib.items.directories.base.item_builder_mdblist import BaseDirItemMDbListBuilder
 from jurialmunkey.ftools import cached_property
-
-
-class BaseDirItemMDbListBuilder(BaseDirItemBuilder):
-    @cached_property
-    def context_menu(self):
-        if not self.base_item.sorting:
-            return []
-        return [(
-            self.base_item.sort_label,
-            RUNSCRIPT.format('sort_mdblist,{}'.format(','.join(f'{k}={v}' for k, v in self.params.items())))
-        )]
-
-    @cached_property
-    def infoproperties(self):
-        infoproperties = super().infoproperties
-        infoproperties['is_sortable'] = 'mdblist' if self.base_item.sorting else None
-        return infoproperties
 
 
 class BaseDirItemMDbListTopLists(BaseDirItem):

--- a/resources/tmdbhelper/lib/items/directories/base/basedir_mdblist.py
+++ b/resources/tmdbhelper/lib/items/directories/base/basedir_mdblist.py
@@ -25,7 +25,7 @@ class BaseDirItemMDbListWatchlist(BaseDirItemMDbListTopLists):
     params = {'info': 'mdblist_watchlist'}
     sorting = True
     item_builder = BaseDirItemMDbListBuilder
-    art_icon = 'resources/icons/sync/watchlist.png'
+    art_icon = 'resources/icons/mdblist/mdblist.png'
     types = ('movie', )
     group = 32193
 
@@ -53,7 +53,7 @@ class BaseDirItemMDbListNextEpisodes(BaseDirItemMDbListTopLists):
     label_localized = 32197
     label_suffix = '(MDbList)'
     params = {'info': 'mdblist_nextepisodes'}
-    art_icon = 'resources/icons/trakt/inprogress.png'
+    art_icon = 'resources/icons/mdblist/mdblist.png'
     types = ('tv', )
     group = 32196
 

--- a/resources/tmdbhelper/lib/items/directories/base/item_builder_mdblist.py
+++ b/resources/tmdbhelper/lib/items/directories/base/item_builder_mdblist.py
@@ -1,0 +1,20 @@
+from tmdbhelper.lib.items.directories.base.item_builder import BaseDirItemBuilder
+from tmdbhelper.lib.addon.consts import RUNSCRIPT
+from jurialmunkey.ftools import cached_property
+
+
+class BaseDirItemMDbListBuilder(BaseDirItemBuilder):
+    @cached_property
+    def context_menu(self):
+        if not self.base_item.sorting:
+            return []
+        return [(
+            self.base_item.sort_label,
+            RUNSCRIPT.format('sort_mdblist,{}'.format(','.join(f'{k}={v}' for k, v in self.params.items())))
+        )]
+
+    @cached_property
+    def infoproperties(self):
+        infoproperties = super().infoproperties
+        infoproperties['is_sortable'] = 'mdblist' if self.base_item.sorting else None
+        return infoproperties

--- a/resources/tmdbhelper/lib/items/directories/base/lists_base.py
+++ b/resources/tmdbhelper/lib/items/directories/base/lists_base.py
@@ -192,8 +192,8 @@ class ListBaseDir(ContainerDirectory):
 
     def get_items(self, info=None, group=None, **kwargs):
         routes = {
-            'dir_movie': lambda: BaseDirList(tmdb=True, trakt=True, sync=True).build_basedir('movie', group=group),
-            'dir_tv': lambda: BaseDirList(tmdb=True, trakt=True, sync=True).build_basedir('tv', group=group),
+            'dir_movie': lambda: BaseDirList(tmdb=True, trakt=True, sync=True, mdblist=True).build_basedir('movie', group=group),
+            'dir_tv': lambda: BaseDirList(tmdb=True, trakt=True, sync=True, mdblist=True).build_basedir('tv', group=group),
             'dir_person': lambda: BaseDirList(tmdb=True, trakt=True, sync=True).build_basedir('person', group=group),
             'dir_tmdb': lambda: BaseDirList(tmdb=True).build_basedir(group=group, info='dir_tmdb'),
             'dir_trakt': lambda: BaseDirList(trakt=True).build_basedir(group=group, info='dir_trakt'),

--- a/resources/tmdbhelper/lib/items/directories/mdblist/lists_custom.py
+++ b/resources/tmdbhelper/lib/items/directories/mdblist/lists_custom.py
@@ -52,7 +52,7 @@ class ListMDbListCustomProperties(ListMDbListLocalProperties):
 
     @cached_property
     def offset(self):
-        return ((self.page - 1) * 20)
+        return ((self.page - 1) * self.limit)
 
     @cached_property
     def response_kwgs(self):

--- a/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
+++ b/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
@@ -140,6 +140,10 @@ class ListMDbListNextEpisodes(ListStandard):
         list_properties.container_content = 'episodes'
         return list_properties
 
+    @cached_property
+    def thumb_override(self):
+        return get_setting('calendar_art', 'int')
+
     def get_items(self, page=1, length=None, **kwargs):
         self.list_properties.page = try_int(page) or 1
         self.list_properties.length = try_int(length)

--- a/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
+++ b/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
@@ -1,0 +1,146 @@
+from datetime import date
+
+from tmdbhelper.lib.items.directories.mdblist.lists_custom import (
+    ListMDbListCustom,
+    ListMDbListCustomProperties,
+    UncachedMDbListCustomData,
+)
+from tmdbhelper.lib.items.directories.mdblist.mapper_upnext import MDbListUpNextItemMapper
+from tmdbhelper.lib.items.directories.tmdb.lists_standard import ListStandard
+from tmdbhelper.lib.addon.plugin import get_setting
+from jurialmunkey.ftools import cached_property
+from jurialmunkey.parser import try_int
+
+
+class ListMDbListWatchlistProperties(ListMDbListCustomProperties):
+
+    released_from = None
+    released_to = None
+
+    @cached_property
+    def url(self):
+        return 'watchlist/items'
+
+    @cached_property
+    def response_kwgs(self):
+        response_kwgs = super().response_kwgs
+        response_kwgs.update({
+            k: v for k, v in (
+                ('mediatype', 'show' if self.tmdb_type == 'tv' else self.tmdb_type),
+                ('released_from', self.released_from),
+                ('released_to', self.released_to),
+            ) if v
+        })
+        return response_kwgs
+
+
+class ListMDbListWatchlist(ListMDbListCustom):
+
+    list_properties_class = ListMDbListWatchlistProperties
+
+    def configure_list_properties(self, list_properties):
+        list_properties = super().configure_list_properties(list_properties)
+        list_properties.localize = 32193
+        list_properties.list_id = 'watchlist'
+        return list_properties
+
+    def get_items(
+        self,
+        tmdb_type,
+        page=1,
+        length=None,
+        sort_by=None,
+        sort_how=None,
+        **kwargs
+    ):
+        self.list_properties.tmdb_type = tmdb_type
+        self.list_properties.page = try_int(page) or 1
+        self.list_properties.length = try_int(length)
+        self.list_properties.sort_by = sort_by or self.list_properties.sort_by
+        self.list_properties.sort_how = sort_how or self.list_properties.sort_how
+        return self.get_items_finalised()
+
+
+class ListMDbListWatchlistReleased(ListMDbListWatchlist):
+    def configure_list_properties(self, list_properties):
+        list_properties = super().configure_list_properties(list_properties)
+        list_properties.localize = 32456
+        list_properties.sort_by = 'released'
+        list_properties.sort_how = 'desc'
+        list_properties.released_to = date.today().isoformat()
+        return list_properties
+
+
+class ListMDbListWatchlistAnticipated(ListMDbListWatchlist):
+    def configure_list_properties(self, list_properties):
+        list_properties = super().configure_list_properties(list_properties)
+        list_properties.localize = 32457
+        list_properties.sort_by = 'released'
+        list_properties.sort_how = 'asc'
+        list_properties.released_from = date.today().isoformat()
+        return list_properties
+
+
+class UncachedMDbListUpNextData(UncachedMDbListCustomData):
+    @cached_property
+    def response_data(self):
+        return self.response.json() or {}
+
+    @cached_property
+    def json(self):
+        return self.response_data.get('items') or []
+
+    @cached_property
+    def item_count(self):
+        return ((self.page - 1) * self.limit) + len(self.json)
+
+    @cached_property
+    def page_count(self):
+        return self.page + 1 if self.response_data.get('has_more') else self.page
+
+
+class ListMDbListNextEpisodesProperties(ListMDbListCustomProperties):
+
+    @cached_property
+    def limit(self):
+        return min(super().limit, 100)
+
+    @cached_property
+    def cache_name_tuple(self):
+        return (
+            self.class_name,
+            self.tmdb_type,
+            self.page,
+            self.limit,
+        )
+
+    def get_api_response(self, page=1):
+        response = self.mdblist_api.get_response(
+            'upnext',
+            limit=self.limit,
+            offset=((self.page - 1) * self.limit),
+        )
+        return UncachedMDbListUpNextData(response, self.page, self.limit).data
+
+    def get_mapped_item(self, item, add_infoproperties=None):
+        return MDbListUpNextItemMapper(item, add_infoproperties).item
+
+
+class ListMDbListNextEpisodes(ListStandard):
+
+    list_properties_class = ListMDbListNextEpisodesProperties
+
+    def configure_list_properties(self, list_properties):
+        list_properties = super().configure_list_properties(list_properties)
+        list_properties.plugin_name = '{localized}'
+        list_properties.localize = 32197
+        list_properties.mdblist_api = self.mdblist_api
+        list_properties.page_length = get_setting('pagemulti_trakt', 'int') or 1
+        list_properties.tmdb_type = 'tv'
+        list_properties.container_content = 'episodes'
+        return list_properties
+
+    def get_items(self, page=1, length=None, **kwargs):
+        self.list_properties.page = try_int(page) or 1
+        self.list_properties.length = try_int(length)
+        return self.get_items_finalised()

--- a/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
+++ b/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
@@ -101,6 +101,8 @@ class UncachedMDbListUpNextData(UncachedMDbListCustomData):
 
 class ListMDbListNextEpisodesProperties(ListMDbListCustomProperties):
 
+    sort_by = 'airdate'
+
     @cached_property
     def limit(self):
         return min(super().limit, 100)
@@ -125,6 +127,42 @@ class ListMDbListNextEpisodesProperties(ListMDbListCustomProperties):
     def get_mapped_item(self, item, add_infoproperties=None):
         return MDbListUpNextItemMapper(item, add_infoproperties).item
 
+    @staticmethod
+    def get_airdate(item):
+        return item.get('infolabels', {}).get('premiered') or ''
+
+    @staticmethod
+    def get_last_watched_at(item):
+        return item.get('infoproperties', {}).get('last_watched_at') or ''
+
+    @cached_property
+    def sort_by_days(self):
+        return -1 if self.sort_by == 'todays' else -7
+
+    def is_recently_aired(self, item):
+        from tmdbhelper.lib.addon.tmdate import is_future_timestamp
+        airdate = self.get_airdate(item)
+        return airdate and is_future_timestamp(
+            airdate,
+            time_fmt='%Y-%m-%d',
+            time_lim=10,
+            use_today=True,
+            days=self.sort_by_days,
+        )
+
+    @cached_property
+    def sorted_items(self):
+        items = sorted(
+            self.filtered_items,
+            key=self.get_airdate if self.sort_by == 'airdate' else self.get_last_watched_at,
+            reverse=True,
+        )
+        if self.sort_by not in ('todays', 'lastweek'):
+            return items
+        recently_aired = [item for item in items if self.is_recently_aired(item)]
+        recently_aired = sorted(recently_aired, key=self.get_airdate, reverse=True)
+        return recently_aired + [item for item in items if item not in recently_aired]
+
 
 class ListMDbListNextEpisodes(ListStandard):
 
@@ -136,6 +174,7 @@ class ListMDbListNextEpisodes(ListStandard):
         list_properties.localize = 32197
         list_properties.mdblist_api = self.mdblist_api
         list_properties.page_length = get_setting('pagemulti_trakt', 'int') or 1
+        list_properties.sort_by = get_setting('trakt_nextepisodesort', 'str') or 'airdate'
         list_properties.tmdb_type = 'tv'
         list_properties.container_content = 'episodes'
         return list_properties

--- a/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
+++ b/resources/tmdbhelper/lib/items/directories/mdblist/lists_sync.py
@@ -101,6 +101,10 @@ class UncachedMDbListUpNextData(UncachedMDbListCustomData):
 
 class ListMDbListNextEpisodesProperties(ListMDbListCustomProperties):
 
+    # Up Next changes as soon as an episode is watched. Kodi refreshes home
+    # widgets after playback, so this user-specific feed must not reuse the
+    # generic six-hour list cache on the subsequent directory build.
+    cache_days = 0
     sort_by = 'airdate'
 
     @cached_property

--- a/resources/tmdbhelper/lib/items/directories/mdblist/mapper_upnext.py
+++ b/resources/tmdbhelper/lib/items/directories/mdblist/mapper_upnext.py
@@ -1,0 +1,70 @@
+from tmdbhelper.lib.items.directories.trakt.mapper_basic import ItemMapper
+from jurialmunkey.ftools import cached_property
+
+
+class MDbListUpNextItemMapper(ItemMapper):
+
+    @cached_property
+    def show(self):
+        return self.meta.get('show') or {}
+
+    @cached_property
+    def episode_data(self):
+        return self.meta.get('next_episode') or {}
+
+    @cached_property
+    def show_tmdb_id(self):
+        return (self.show.get('ids') or {}).get('tmdb')
+
+    @cached_property
+    def episode_tmdb_id(self):
+        return (self.episode_data.get('ids') or {}).get('tmdb')
+
+    @cached_property
+    def label(self):
+        return self.episode_data.get('title') or self.show.get('title') or ''
+
+    def get_infolabels(self):
+        return {
+            'mediatype': 'episode',
+            'title': self.episode_data.get('title'),
+            'tvshowtitle': self.show.get('title'),
+            'season': self.episode_data.get('season'),
+            'episode': self.episode_data.get('episode'),
+            'premiered': self.episode_data.get('air_date'),
+            'year': self.show.get('year'),
+        }
+
+    def get_infoproperties(self):
+        progress = self.meta.get('progress') or {}
+        return {
+            'tmdb_type': 'tv',
+            'tmdb_id': self.show_tmdb_id,
+            'last_watched_at': self.meta.get('last_watched_at'),
+            'is_newly_aired': self.meta.get('is_newly_aired'),
+            'watched_episode_count': progress.get('watched_episode_count'),
+            'total_episode_count': progress.get('total_episode_count'),
+        }
+
+    def get_unique_ids(self):
+        return {
+            'tmdb': self.show_tmdb_id,
+            'tvshow.tmdb': self.show_tmdb_id,
+            'episode.tmdb': self.episode_tmdb_id,
+            'mdblist': (self.show.get('ids') or {}).get('mdblist'),
+        }
+
+    def get_art(self):
+        return {
+            'poster': self.show.get('poster'),
+            'thumb': self.episode_data.get('still'),
+        }
+
+    def get_params(self):
+        return {
+            'info': 'details',
+            'tmdb_type': 'tv',
+            'tmdb_id': self.show_tmdb_id,
+            'season': self.episode_data.get('season'),
+            'episode': self.episode_data.get('episode'),
+        }


### PR DESCRIPTION
## What changed

- add MDBList `Next Episodes` under TV Shows using the `/upnext` endpoint
- add MDBList movie Watchlist, Watchlist (Released), and Watchlist (Anticipated) entries under Movies
- support MDBList's full list sorting menu for the new watchlist routes
- filter released and anticipated watchlists server-side with `released_to` / `released_from`
- map MDBList's nested Up Next response into TMDBHelper episode items for normal TMDb enrichment
- fix MDBList offset pagination to account for the configured multi-page request size

## Why

MDBList currently appears in TMDBHelper primarily as a user-list provider. These additions make its watchlist and next-episode APIs usable as direct widget sources, paralleling the most important Trakt routes after Trakt's API restrictions.

## Validation

- `python3 -m compileall` on all changed modules
- `git diff --check`
- live authenticated smoke test against MDBList `/upnext`, including conversion to a Kodi episode item
- verified watchlist filtering and sorting parameters against the current MDBList OpenAPI schema
