### PR TITLE
Fix TypeError in Item.get_item_id (scrobbler crash on playback stop)

### DIFF
--- a/resources/tmdbhelper/lib/script/sync/item.py
+++ b/resources/tmdbhelper/lib/script/sync/item.py
@@ -221,7 +221,7 @@ class ItemSync:
         return self.get_item_id()
 
     def get_item_id(self):
-        return '.'.join([i for i in (self.tmdb_id, self.season, self.episode) if i])
+        return '.'.join([str(i) for i in (self.tmdb_id, self.season, self.episode) if i])
 
     """
     status_code


### PR DESCRIPTION
## Problem

`Item.get_item_id()` builds an id by joining `(tmdb_id, season, episode)` with `'.'`:

```python
return '.'.join([i for i in (self.tmdb_id, self.season, self.episode) if i])
```

`season` and `episode` are ints, so `str.join` raises:

```
TypeError: sequence item 1: expected str instance, int found
```

This crashes the scrobbler on **every playback stop of an episode watched to >=80%**:

```
onPlayBackStopped (monitor/player.py)
  -> scrobbler.stop (monitor/scrobbler.py)
    -> set_tmdb_ratings   # runs at progress >= 80%
      -> sync_item(sync_type='rating')  (script/sync/tmdb/menu.py)
        -> menu.select -> choices[x].sync -> Item.get_item_id  # TypeError
```

Because `onPlayBackStopped` aborts, post-playback cleanup doesn't complete, which on some setups leaves the player monitor in a state where the just-watched episode is reloaded/replayed.

Reproduced on 6.16.2 (Kodi 21, Android). The buggy line is present on both `nexus` and `master`.

## Fix

Cast each id to `str` before joining (movies pass too — `season`/`episode` are `None` and filtered out by the existing `if i`):

```python
return '.'.join([str(i) for i in (self.tmdb_id, self.season, self.episode) if i])
```

One-line, no behavior change for the already-string cases.