### PR TITLE
Refresh MDBList activity cache and widgets after playback

### DIFF
--- a/resources/tmdbhelper/lib/monitor/player.py
+++ b/resources/tmdbhelper/lib/monitor/player.py
@@ -208,11 +208,25 @@ class PlayerMonitor(Player, CommonMonitorFunctions):
 
     def onPlayBackEnded(self):
         self.scrobbler_stop()
+        self.refresh_mdblist_watched()
         self.reset_properties()
 
     def onPlayBackStopped(self):
         self.scrobbler_stop()
+        self.refresh_mdblist_watched()
         self.reset_properties()
+
+    def refresh_mdblist_watched(self):
+        if get_setting('sync_source_watched', 'str') != 'MDbList':
+            return
+        if not get_setting('mdblist_scrobbling'):
+            return
+        from tmdbhelper.lib.addon.consts import LASTACTIVITIES_DATA
+        from tmdbhelper.lib.addon.logger import kodi_log
+        from tmdbhelper.lib.addon.tmdate import set_timestamp
+        self.get_property(LASTACTIVITIES_DATA, clear_property=True)
+        self.get_property('Widgets.Reload', set_property=f'{set_timestamp(0, True)}')
+        kodi_log('Sync: invalidated MDbList watched activities after playback', 2)
 
     def onPlayBackPaused(self):
         self.scrobbler_pause()


### PR DESCRIPTION
When MDBList has recorded an episode as watched, TMDb Helper's Next Episodes widget can continue displaying it until a later activity check or manual sync.

This clears `LASTACTIVITIES_DATA` and updates `Widgets.Reload` from `PlayerMonitor.onPlayBackEnded()` and `onPlayBackStopped()`, after stopping the scrobbler. It applies when MDBList is selected as the watched source and MDBList scrobbling is enabled. Using the playback callbacks also covers external players whose playback does not reach TMDb Helper's scrobbler update hook.

The next widget request checks current activities through the existing sync logic. Database checkpoints are preserved so incremental requests can continue using `since`; the callback does not invoke `SyncInvalidator` or force a full watched-history resync.

Validation: Python compilation and `git diff --check` pass. This matches the locally tested 6.16.907 build: with Red Light and an Arctic Fuse 3 TMDb Helper Next Episodes widget, an episode already recorded as watched in MDBList disappeared after playback stopped. This change refreshes local data; it does not address a player failing to submit a watched update to MDBList.
