### PR TITLE
⚡ Add RottenTomatoes_Image and Metacritic_Image for "Must See" via MDBList keywords

### DIFF
--- a/resources/tmdbhelper/lib/api/mdblist/api.py
+++ b/resources/tmdbhelper/lib/api/mdblist/api.py
@@ -67,6 +67,40 @@ class MDbListRatingMappingObject:
         return self.ratings.items()
 
 
+class MDbListKeywordRatingMappingObject(MDbListRatingMappingObject):
+    votes_key = None
+    votes_value = None
+
+    rating_keywords = {
+        'certified-fresh': ('rottentomatoes_image', 'certified'),
+        'fresh': ('rottentomatoes_image', 'fresh'),
+        'rotten': ('rottentomatoes_image', 'rotten'),
+        'certified-hot': ('rottentomatoes_usermeter_image', 'hot'),
+        'metacritic-must-see': ('metacritic_image', 'mustsee'),
+    }
+
+    @cached_property
+    def name(self):
+        try:
+            return self.meta['name']
+        except KeyError:
+            return
+
+    @cached_property
+    def rating_key(self):
+        try:
+            return self.rating_keywords[self.name][0]
+        except KeyError:
+            return
+
+    @cached_property
+    def rating_value(self):
+        try:
+            return self.rating_keywords[self.name][1]
+        except KeyError:
+            return
+
+
 class MDbListRatingMapping:
     def __init__(self, meta):
         self.meta = meta
@@ -79,6 +113,13 @@ class MDbListRatingMapping:
             return []
 
     @cached_property
+    def meta_keywords(self):
+        try:
+            return self.meta['keywords']
+        except (KeyError, TypeError):
+            return []
+
+    @cached_property
     def ratings(self):
         ratings = {
             k: v
@@ -86,6 +127,13 @@ class MDbListRatingMapping:
             for k, v in MDbListRatingMappingObject(i).items()
         }
         ratings['mdblist_rating'] = self.meta.get('score')
+
+        ratings.update({
+            k: v
+            for d in self.meta_keywords
+            for k, v in MDbListKeywordRatingMappingObject(d).items()
+        })
+
         return ratings
 
 
@@ -107,8 +155,8 @@ class MDbList(RequestAPI):
         path = self.get_request_url('lists', list_id, 'items', action)
         return self.get_api_request(path, postdata=item, method='json')
 
-    def get_details(self, media_type, media_id, media_provider='tmdb'):
-        return self.get_request_sc(media_provider, media_type, media_id)  # TODO: Add append_to_response=review ?
+    def get_details(self, media_type, media_id, media_provider='tmdb', append_to_response='keyword'):
+        return self.get_request_sc(media_provider, media_type, media_id, append_to_response=append_to_response)  # TODO: Add append_to_response=review ?
 
     def get_ratings(self, media_type, media_id, media_provider='tmdb'):
         response = self.get_details(media_type, media_id, media_provider=media_provider)

--- a/resources/tmdbhelper/lib/api/mdblist/api.py
+++ b/resources/tmdbhelper/lib/api/mdblist/api.py
@@ -77,6 +77,7 @@ class MDbListKeywordRatingMappingObject(MDbListRatingMappingObject):
         'rotten': ('rottentomatoes_image', 'rotten'),
         'certified-hot': ('rottentomatoes_usermeter_image', 'hot'),
         'metacritic-must-see': ('metacritic_image', 'mustsee'),
+        'roger-ebert-thumbs-down': ('rogerebert_image', 'thumbsdown'),
     }
 
     @cached_property

--- a/resources/tmdbhelper/lib/items/database/database.py
+++ b/resources/tmdbhelper/lib/items/database/database.py
@@ -45,7 +45,7 @@ class ItemDetailsDatabase(Database):
         super().__init__(filename=self.cache_filename)
 
     # DB version must be max of table_version
-    database_version = 44
+    database_version = 45
 
     database_changes = {
         21: (),
@@ -112,6 +112,10 @@ class ItemDetailsDatabase(Database):
         ),
          44: (
             'ALTER TABLE ratings ADD myanimelist_rating INTEGER',
+        ),
+        45: (
+            'ALTER TABLE ratings ADD metacritic_image TEXT',
+            'ALTER TABLE ratings ADD rottentomatoes_usermeter_image TEXT',
         ),
     }
 

--- a/resources/tmdbhelper/lib/items/database/database.py
+++ b/resources/tmdbhelper/lib/items/database/database.py
@@ -117,6 +117,7 @@ class ItemDetailsDatabase(Database):
             'ALTER TABLE ratings ADD metacritic_image TEXT',
             'ALTER TABLE ratings ADD rottentomatoes_usermeter_image TEXT',
             'ALTER TABLE ratings ADD rogerebert_rating INTEGER',
+            'ALTER TABLE ratings ADD rogerebert_image TEXT',
         ),
     }
 

--- a/resources/tmdbhelper/lib/items/database/database.py
+++ b/resources/tmdbhelper/lib/items/database/database.py
@@ -116,6 +116,7 @@ class ItemDetailsDatabase(Database):
         45: (
             'ALTER TABLE ratings ADD metacritic_image TEXT',
             'ALTER TABLE ratings ADD rottentomatoes_usermeter_image TEXT',
+            'ALTER TABLE ratings ADD rogerebert_rating INTEGER',
         ),
     }
 

--- a/resources/tmdbhelper/lib/items/database/tabledef.py
+++ b/resources/tmdbhelper/lib/items/database/tabledef.py
@@ -320,8 +320,14 @@ RATINGS_COLUMNS = {
     'rottentomatoes_image': {
         'data': 'TEXT',
     },
+    'rottentomatoes_usermeter_image': {
+        'data': 'TEXT',
+    },
     'metacritic_rating': {
         'data': 'INTEGER',
+    },
+    'metacritic_image': {
+        'data': 'TEXT',
     },
     'trakt_rating': {
         'data': 'INTEGER',

--- a/resources/tmdbhelper/lib/items/database/tabledef.py
+++ b/resources/tmdbhelper/lib/items/database/tabledef.py
@@ -347,6 +347,9 @@ RATINGS_COLUMNS = {
     'mdblist_votes': {
         'data': 'INTEGER',
     },
+    'rogerebert_rating': {
+        'data': 'INTEGER',
+    },
     'myanimelist_rating': {
         'data': 'INTEGER',
     },

--- a/resources/tmdbhelper/lib/items/database/tabledef.py
+++ b/resources/tmdbhelper/lib/items/database/tabledef.py
@@ -350,6 +350,9 @@ RATINGS_COLUMNS = {
     'rogerebert_rating': {
         'data': 'INTEGER',
     },
+    'rogerebert_image': {
+        'data': 'TEXT',
+    },
     'myanimelist_rating': {
         'data': 'INTEGER',
     },


### PR DESCRIPTION
Resolves #1895

Still not sure how ratings are prioritized from OMDb vs MDBList. I'm still guessing that the faster API wins?

Unfortunately, `ALTER TABLE` adds the columns at the end instead of respecting the position (i.e., I'd have preferred to keep `metacritic_image` after `metacritic_rating` and `rottentomtoes_usermeter_image` after `rottentomatoes_image`) but that's not worth dropping the entire ratings table haha.

AF3 PR coming shortly!
