### PR TITLE
⚡ Add Metacritic ratings to MDBList

### DIFF
--- a/resources/tmdbhelper/lib/api/mdblist/api.py
+++ b/resources/tmdbhelper/lib/api/mdblist/api.py
@@ -7,7 +7,8 @@ class MDbListRatingMappingObject:
     rating_keys = {
         'tomatoes': 'rottentomatoes_rating',
         'tomatoesaudience': 'rottentomatoes_usermeter',
-        'popcorn': 'rottentomatoes_usermeter'}
+        'popcorn': 'rottentomatoes_usermeter',
+        'metacritic': 'metacritic_rating'}
 
     rating_func = {
         'imdb': lambda v: int(v * 10),  # Convert out of /10 to 100%

--- a/resources/tmdbhelper/lib/items/database/baseview_factories/concrete_classes/ratings.py
+++ b/resources/tmdbhelper/lib/items/database/baseview_factories/concrete_classes/ratings.py
@@ -145,6 +145,7 @@ class RatingsDict(BaseList):
             'tmdb_rating': lambda v: f'{(v / 10):.1f}',
             'trakt_rating': lambda v: f'{(v / 10):.1f}',
             'imdb_rating': lambda v: f'{(v / 10):.1f}',
+            'metacriticuser_rating': lambda v: f'{(v / 10):.1f}',
             'letterboxd_rating': lambda v: f'{(v / 20):.1f}',  # 5 Star rating
             'rogerebert_rating': lambda v: f'{(v / 25):.1f}',  # 4 Star rating
             'myanimelist_rating': lambda v: f'{(v / 10):.1f}',

--- a/resources/tmdbhelper/lib/items/database/database.py
+++ b/resources/tmdbhelper/lib/items/database/database.py
@@ -114,6 +114,7 @@ class ItemDetailsDatabase(Database):
             'ALTER TABLE ratings ADD myanimelist_rating INTEGER',
         ),
         45: (
+            'ALTER TABLE ratings ADD metacriticuser_rating INTEGER',
             'ALTER TABLE ratings ADD metacritic_image TEXT',
             'ALTER TABLE ratings ADD rottentomatoes_usermeter_image TEXT',
             'ALTER TABLE ratings ADD rogerebert_rating INTEGER',

--- a/resources/tmdbhelper/lib/items/database/tabledef.py
+++ b/resources/tmdbhelper/lib/items/database/tabledef.py
@@ -326,6 +326,9 @@ RATINGS_COLUMNS = {
     'metacritic_rating': {
         'data': 'INTEGER',
     },
+    'metacriticuser_rating': {
+        'data': 'INTEGER',
+    },
     'metacritic_image': {
         'data': 'TEXT',
     },


### PR DESCRIPTION
Adds Metacritic and Metacritic User ratings.

Didn't bump the DB version so needs to go along with https://github.com/jurialmunkey/plugin.video.themoviedb.helper/pull/1896